### PR TITLE
fix: devcontainer script hardening and refactoring

### DIFF
--- a/.devcontainer/config/extra-configuration.py.example
+++ b/.devcontainer/config/extra-configuration.py.example
@@ -16,7 +16,7 @@ ALLOWED_HOSTS = ["*"]
 
 # Dev banners
 BANNER_TOP = "Development Environment"
-BANNER_BOTTOM = "NetBox Interface Name Rules Plugin Dev Container"
+BANNER_BOTTOM = "NetBox Data Import Plugin Dev Container"
 BANNER_LOGIN = "Development access only"
 
 # Example: Custom logging

--- a/.devcontainer/config/plugin-config.py.example
+++ b/.devcontainer/config/plugin-config.py.example
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2025 Marcin Zieba <marcinpsk@gmail.com>
 """
-Plugin configuration for the NetBox Interface Name Rules Plugin in the dev container.
+Plugin configuration for the NetBox Data Import Plugin in the dev container.
 
 - Copy this file to .devcontainer/config/plugin-config.py
 - Edit values as needed.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "NetBox Interface Name Rules Plugin Dev",
+  "name": "NetBox Data Import Plugin Dev",
   "dockerComposeFile": "docker-compose.yml",
   "service": "devcontainer",
   "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",

--- a/.devcontainer/scripts/diagnose.sh
+++ b/.devcontainer/scripts/diagnose.sh
@@ -60,7 +60,7 @@ if command -v netstat >/dev/null 2>&1; then
 elif command -v ss >/dev/null 2>&1; then
   echo "  - Port 8000: $(ss -tuln 2>/dev/null | grep :8000 >/dev/null && echo 'Listening' || echo 'Not listening')"
 else
-  echo "  - Port 8000: $(awk 'BEGIN{r="Not listening"} $2 ~ /:1F40$/ && $4 == "0A" {r="Listening"; exit} END{print r}' /proc/net/tcp 2>/dev/null)"
+  echo "  - Port 8000: $(awk 'BEGIN{r="Not listening"} $2 ~ /:1F40$/ && $4 == "0A" {r="Listening"; exit} END{print r}' /proc/net/tcp /proc/net/tcp6 2>/dev/null)"
 fi
 
 echo ""

--- a/.devcontainer/scripts/diagnose.sh
+++ b/.devcontainer/scripts/diagnose.sh
@@ -14,7 +14,7 @@ echo ""
 echo "🐳 Container Environment:"
 echo "  - NETBOX_VERSION: ${NETBOX_VERSION:-not set}"
 echo "  - DEBUG: ${DEBUG:-not set}"
-echo "  - SECRET_KEY: ${SECRET_KEY:0:20}... (truncated)"
+echo "  - SECRET_KEY: $([ -n "$SECRET_KEY" ] && echo 'set' || echo 'unset')"
 echo "  - DB_HOST: ${DB_HOST:-not set}"
 echo "  - DB_NAME: ${DB_NAME:-not set}"
 echo "  - DB_USER: ${DB_USER:-not set}"
@@ -60,7 +60,7 @@ if command -v netstat >/dev/null 2>&1; then
 elif command -v ss >/dev/null 2>&1; then
   echo "  - Port 8000: $(ss -tuln 2>/dev/null | grep :8000 >/dev/null && echo 'Listening' || echo 'Not listening')"
 else
-  echo "  - Port 8000: $(cat /proc/net/tcp 2>/dev/null | awk '$2 ~ /:1F40$/ {print "Listening"; exit}' | grep -q "Listening" && echo 'Listening' || echo 'Not listening')"
+  echo "  - Port 8000: $(awk 'BEGIN{r="Not listening"} $2 ~ /:1F40$/ && $4 == "0A" {r="Listening"; exit} END{print r}' /proc/net/tcp 2>/dev/null)"
 fi
 
 echo ""

--- a/.devcontainer/scripts/diagnose.sh
+++ b/.devcontainer/scripts/diagnose.sh
@@ -5,15 +5,21 @@
 echo "🔍 DevContainer Startup Diagnostics"
 echo "=================================="
 
+PLUGIN_WS_DIR="${PLUGIN_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
 echo "📍 Current working directory: $(pwd)"
 echo "👤 Current user: $(whoami)"
+echo "🆔 User ID: $(id)"
 
 echo ""
 echo "🐳 Container Environment:"
 echo "  - NETBOX_VERSION: ${NETBOX_VERSION:-not set}"
 echo "  - DEBUG: ${DEBUG:-not set}"
+echo "  - SECRET_KEY: ${SECRET_KEY:0:20}... (truncated)"
 echo "  - DB_HOST: ${DB_HOST:-not set}"
+echo "  - DB_NAME: ${DB_NAME:-not set}"
+echo "  - DB_USER: ${DB_USER:-not set}"
 echo "  - REDIS_HOST: ${REDIS_HOST:-not set}"
+echo "  - SUPERUSER_NAME: ${SUPERUSER_NAME:-not set}"
 
 echo ""
 echo "🔗 Service Connectivity:"
@@ -23,29 +29,38 @@ echo "  - Redis: $(timeout 3 bash -c 'cat < /dev/null > /dev/tcp/redis/6379' 2>/
 echo ""
 echo "🗂️ File System:"
 echo "  - NetBox venv: $(test -f /opt/netbox/venv/bin/activate && echo 'Exists' || echo 'Missing')"
-echo "  - Plugin directory: $(test -d /workspaces/netbox-data-import-plugin && echo 'Exists' || echo 'Missing')"
-echo "  - Plugin config: $(test -f /workspaces/netbox-data-import-plugin/.devcontainer/config/plugin-config.py && echo 'Found' || echo 'Missing (using defaults)')"
-echo "  - Extra plugins config: $(test -f /workspaces/netbox-data-import-plugin/.devcontainer/config/extra-plugins.py && echo 'Found' || echo 'Not configured')"
+echo "  - Plugin directory: $(test -d "$PLUGIN_WS_DIR" && echo 'Exists' || echo 'Missing')"
+echo "  - Setup script: $(test -f "$PLUGIN_WS_DIR/.devcontainer/scripts/setup.sh" && echo 'Exists' || echo 'Missing')"
+echo "  - Start script: $(test -f "$PLUGIN_WS_DIR/.devcontainer/scripts/start-netbox.sh" && echo 'Exists' || echo 'Missing')"
+echo "  - Start script executable: $(test -x "$PLUGIN_WS_DIR/.devcontainer/scripts/start-netbox.sh" && echo 'Yes' || echo 'No')"
+echo "  - Plugin config: $(test -f "$PLUGIN_WS_DIR/.devcontainer/config/plugin-config.py" && echo 'Found' || echo 'Missing (using defaults)')"
+echo "  - NetBox config path: /opt/netbox/netbox/netbox/configuration.py"
 
 echo ""
 echo "🚀 Process Status:"
 if [ -f /tmp/netbox.pid ]; then
   PID=$(cat /tmp/netbox.pid)
-  if kill -0 "$PID" 2>/dev/null; then
+  if [ -z "$PID" ]; then
+    echo "  - NetBox server: PID file exists but is empty"
+  elif kill -0 "$PID" 2>/dev/null; then
     echo "  - NetBox server: Running (PID: $PID)"
   else
     echo "  - NetBox server: PID file exists but process not running"
+    echo "    (PID $PID is dead - NetBox may have crashed)"
   fi
 else
   echo "  - NetBox server: Not started"
 fi
 
+# Check port listening
 echo ""
 echo "🌍 Port Check:"
-if command -v ss >/dev/null 2>&1; then
-  echo "  - Port 8000: $(ss -tuln 2>/dev/null | grep :8000 >/dev/null && echo 'Listening' || echo 'Not listening')"
-elif command -v netstat >/dev/null 2>&1; then
+if command -v netstat >/dev/null 2>&1; then
   echo "  - Port 8000: $(netstat -tuln 2>/dev/null | grep :8000 >/dev/null && echo 'Listening' || echo 'Not listening')"
+elif command -v ss >/dev/null 2>&1; then
+  echo "  - Port 8000: $(ss -tuln 2>/dev/null | grep :8000 >/dev/null && echo 'Listening' || echo 'Not listening')"
+else
+  echo "  - Port 8000: $(cat /proc/net/tcp 2>/dev/null | awk '$2 ~ /:1F40$/ {print "Listening"; exit}' | grep -q "Listening" && echo 'Listening' || echo 'Not listening')"
 fi
 
 echo ""

--- a/.devcontainer/scripts/load-aliases.sh
+++ b/.devcontainer/scripts/load-aliases.sh
@@ -26,7 +26,7 @@ unset _ca_var _val
 # Load shared process management helpers
 if ! source "$PLUGIN_DIR/.devcontainer/scripts/process-helpers.sh"; then
   printf '%s\n' "Failed to load process-helpers.sh" >&2
-  return 1
+  return 1 2>/dev/null || exit 1
 fi
 
 netbox-run-bg() { "$PLUGIN_DIR/.devcontainer/scripts/start-netbox.sh" --background; }
@@ -80,7 +80,7 @@ netbox-restart() {
 
 netbox-reload() {
   cd "$PLUGIN_DIR" || return 1
-  source /opt/netbox/venv/bin/activate
+  source /opt/netbox/venv/bin/activate || return 1
   if command -v uv >/dev/null 2>&1; then
     uv pip install -e . || return 1
   else
@@ -144,7 +144,7 @@ netbox-manage() {
 
 plugin-install() {
   cd "$PLUGIN_DIR" || return 1
-  source /opt/netbox/venv/bin/activate
+  source /opt/netbox/venv/bin/activate || return 1
   if command -v uv >/dev/null 2>&1; then
     uv pip install -e .
   else
@@ -154,7 +154,7 @@ plugin-install() {
 
 plugins-install() {
   if [ -f "$PLUGIN_DIR/.devcontainer/extra-requirements.txt" ]; then
-    source /opt/netbox/venv/bin/activate
+    source /opt/netbox/venv/bin/activate || return 1
     if command -v uv >/dev/null 2>&1; then
       uv pip install -r "$PLUGIN_DIR/.devcontainer/extra-requirements.txt"
     else
@@ -165,9 +165,9 @@ plugins-install() {
   fi
 }
 
-ruff-check() { cd "$PLUGIN_DIR" && command ruff check .; }
-ruff-format() { cd "$PLUGIN_DIR" && command ruff format .; }
-ruff-fix()    { cd "$PLUGIN_DIR" && command ruff check --fix .; }
+ruff-check() { (cd "$PLUGIN_DIR" && command ruff check .); }
+ruff-format() { (cd "$PLUGIN_DIR" && command ruff format .); }
+ruff-fix()    { (cd "$PLUGIN_DIR" && command ruff check --fix .); }
 
 diagnose() { "$PLUGIN_DIR/.devcontainer/scripts/diagnose.sh"; }
 

--- a/.devcontainer/scripts/load-aliases.sh
+++ b/.devcontainer/scripts/load-aliases.sh
@@ -39,7 +39,7 @@ netbox-stop() {
     local PID
     PID=$(cat /tmp/netbox.pid 2>/dev/null)
     if [ -n "$PID" ] && kill -0 "$PID" 2>/dev/null; then
-      if is_expected_pid "$PID" "python.*runserver.*8000"; then
+      if is_expected_pid "$PID" "manage\.py runserver.*8000"; then
         graceful_kill_pid "$PID"
         echo "   Stopped NetBox (PID: $PID)"
       else
@@ -52,7 +52,7 @@ netbox-stop() {
     local PID
     PID=$(cat /tmp/rqworker.pid 2>/dev/null)
     if [ -n "$PID" ] && kill -0 "$PID" 2>/dev/null; then
-      if is_expected_pid "$PID" "python.*rqworker"; then
+      if is_expected_pid "$PID" "manage\.py rqworker"; then
         graceful_kill_pid "$PID"
         echo "   Stopped RQ worker (PID: $PID)"
       else
@@ -61,14 +61,14 @@ netbox-stop() {
     fi
     rm -f /tmp/rqworker.pid
   fi
-  if pgrep -f "python.*rqworker" >/dev/null 2>&1; then
+  if pgrep -f "manage\.py rqworker" >/dev/null 2>&1; then
     local ORPHAN_COUNT
-    ORPHAN_COUNT=$(pgrep -cf "python.*rqworker" 2>/dev/null || echo 0)
-    graceful_kill_pattern "python.*rqworker"
+    ORPHAN_COUNT=$(pgrep -cf "manage\.py rqworker" 2>/dev/null || echo 0)
+    graceful_kill_pattern "manage\.py rqworker"
     echo "   Killed $ORPHAN_COUNT orphaned RQ worker(s)"
   fi
-  if pgrep -f "python.*runserver.*8000" >/dev/null 2>&1; then
-    graceful_kill_pattern "python.*runserver.*8000"
+  if pgrep -f "manage\.py runserver.*8000" >/dev/null 2>&1; then
+    graceful_kill_pattern "manage\.py runserver.*8000"
     echo "   Killed orphaned NetBox server(s)"
   fi
   echo "✅ All processes stopped"
@@ -95,7 +95,7 @@ netbox-status() {
   local PID
   if [ -f /tmp/netbox.pid ]; then
     PID=$(cat /tmp/netbox.pid 2>/dev/null)
-    if [ -n "$PID" ] && is_expected_pid "$PID" "python.*runserver.*8000"; then
+    if [ -n "$PID" ] && is_expected_pid "$PID" "manage\.py runserver.*8000"; then
       echo "NetBox is running (PID: $PID)"
     else
       echo "NetBox is not running"
@@ -105,7 +105,7 @@ netbox-status() {
   fi
   if [ -f /tmp/rqworker.pid ]; then
     PID=$(cat /tmp/rqworker.pid 2>/dev/null)
-    if [ -n "$PID" ] && is_expected_pid "$PID" "python.*rqworker"; then
+    if [ -n "$PID" ] && is_expected_pid "$PID" "manage\.py rqworker"; then
       echo "RQ worker is running (PID: $PID)"
     else
       echo "RQ worker is not running"
@@ -119,7 +119,7 @@ rq-status() {
   local PID
   if [ -f /tmp/rqworker.pid ]; then
     PID=$(cat /tmp/rqworker.pid 2>/dev/null)
-    if [ -n "$PID" ] && is_expected_pid "$PID" "python.*rqworker"; then
+    if [ -n "$PID" ] && is_expected_pid "$PID" "manage\.py rqworker"; then
       echo "RQ worker is running (PID: $PID)"
     else
       echo "RQ worker is not running"

--- a/.devcontainer/scripts/load-aliases.sh
+++ b/.devcontainer/scripts/load-aliases.sh
@@ -1,121 +1,226 @@
 #!/bin/bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2025 Marcin Zieba <marcinpsk@gmail.com>
-# Shell functions for NetBox Interface Name Rules Plugin development.
+# Shell functions for NetBox Data Import Plugin development.
 # Usage: source .devcontainer/scripts/load-aliases.sh
 
 export PATH="/opt/netbox/venv/bin:$PATH"
 export DEBUG="${DEBUG:-True}"
-PLUGIN_DIR="/workspaces/netbox-data-import-plugin"
+PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
-netbox-run-bg() {
-  "$PLUGIN_DIR/.devcontainer/scripts/start-netbox.sh" --background
-}
+# Clean up empty CA bundle vars (Compose/devcontainer inject "" when host var is
+# unset, which breaks requests/curl).  When setup.sh has installed custom CAs
+# into the system trust store, point to it instead.
+for _ca_var in REQUESTS_CA_BUNDLE SSL_CERT_FILE CURL_CA_BUNDLE; do
+  _val="${!_ca_var}"
+  if [ -z "$_val" ]; then
+    if [ -f /etc/ssl/certs/ca-certificates.crt ]; then
+      declare -x "$_ca_var=/etc/ssl/certs/ca-certificates.crt"
+    else
+      unset "$_ca_var"
+    fi
+  fi
+done
+unset _ca_var _val
 
-netbox-run() {
-  "$PLUGIN_DIR/.devcontainer/scripts/start-netbox.sh"
-}
+# Load shared process management helpers
+if ! source "$PLUGIN_DIR/.devcontainer/scripts/process-helpers.sh"; then
+  printf '%s\n' "Failed to load process-helpers.sh" >&2
+  return 1
+fi
 
+netbox-run-bg() { "$PLUGIN_DIR/.devcontainer/scripts/start-netbox.sh" --background; }
+netbox-run()    { "$PLUGIN_DIR/.devcontainer/scripts/start-netbox.sh"; }
+
+# Robust stop command that kills both tracked and orphaned processes
 netbox-stop() {
-  echo "🛑 Stopping NetBox..."
+  echo "🛑 Stopping NetBox and RQ workers..."
   if [ -f /tmp/netbox.pid ]; then
-    local pid
-    pid=$(cat /tmp/netbox.pid 2>/dev/null)
-    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
-      kill "$pid" 2>/dev/null || kill -9 "$pid" 2>/dev/null
-      echo "   Stopped NetBox (PID: $pid)"
+    local PID
+    PID=$(cat /tmp/netbox.pid 2>/dev/null)
+    if [ -n "$PID" ] && kill -0 "$PID" 2>/dev/null; then
+      if is_expected_pid "$PID" "python.*runserver.*8000"; then
+        graceful_kill_pid "$PID"
+        echo "   Stopped NetBox (PID: $PID)"
+      else
+        echo "   Skipping stale /tmp/netbox.pid (PID $PID is not NetBox runserver)"
+      fi
     fi
     rm -f /tmp/netbox.pid
   fi
+  if [ -f /tmp/rqworker.pid ]; then
+    local PID
+    PID=$(cat /tmp/rqworker.pid 2>/dev/null)
+    if [ -n "$PID" ] && kill -0 "$PID" 2>/dev/null; then
+      if is_expected_pid "$PID" "python.*rqworker"; then
+        graceful_kill_pid "$PID"
+        echo "   Stopped RQ worker (PID: $PID)"
+      else
+        echo "   Skipping stale /tmp/rqworker.pid (PID $PID is not rqworker)"
+      fi
+    fi
+    rm -f /tmp/rqworker.pid
+  fi
+  if pgrep -f "python.*rqworker" >/dev/null 2>&1; then
+    local ORPHAN_COUNT
+    ORPHAN_COUNT=$(pgrep -cf "python.*rqworker" 2>/dev/null || echo 0)
+    graceful_kill_pattern "python.*rqworker"
+    echo "   Killed $ORPHAN_COUNT orphaned RQ worker(s)"
+  fi
   if pgrep -f "python.*runserver.*8000" >/dev/null 2>&1; then
-    pkill -9 -f "python.*runserver.*8000" 2>/dev/null
+    graceful_kill_pattern "python.*runserver.*8000"
     echo "   Killed orphaned NetBox server(s)"
   fi
   echo "✅ All processes stopped"
 }
 
 netbox-restart() {
-  netbox-stop
-  sleep 1
-  netbox-run-bg
+  netbox-stop && sleep 1 && netbox-run-bg
 }
 
 netbox-reload() {
-  cd "$PLUGIN_DIR" && uv pip install -e . && netbox-restart
+  cd "$PLUGIN_DIR" || return 1
+  if command -v uv >/dev/null 2>&1; then
+    uv pip install -e . || return 1
+  else
+    pip install -e . || return 1
+  fi
+  netbox-restart
 }
 
-netbox-logs() {
-  tail -f /tmp/netbox.log
-}
+alias netbox-logs="tail -f /tmp/netbox.log"
+alias rq-logs="tail -f /tmp/rqworker.log"
 
 netbox-status() {
-  if [ -f /tmp/netbox.pid ] && kill -0 "$(cat /tmp/netbox.pid)" 2>/dev/null; then
-    echo "NetBox is running (PID: $(cat /tmp/netbox.pid))"
+  local PID
+  if [ -f /tmp/netbox.pid ]; then
+    PID=$(cat /tmp/netbox.pid 2>/dev/null)
+    if [ -n "$PID" ] && is_expected_pid "$PID" "python.*runserver.*8000"; then
+      echo "NetBox is running (PID: $PID)"
+    else
+      echo "NetBox is not running"
+    fi
   else
     echo "NetBox is not running"
+  fi
+  if [ -f /tmp/rqworker.pid ]; then
+    PID=$(cat /tmp/rqworker.pid 2>/dev/null)
+    if [ -n "$PID" ] && is_expected_pid "$PID" "python.*rqworker"; then
+      echo "RQ worker is running (PID: $PID)"
+    else
+      echo "RQ worker is not running"
+    fi
+  else
+    echo "RQ worker is not running"
+  fi
+}
+
+rq-status() {
+  local PID
+  if [ -f /tmp/rqworker.pid ]; then
+    PID=$(cat /tmp/rqworker.pid 2>/dev/null)
+    if [ -n "$PID" ] && is_expected_pid "$PID" "python.*rqworker"; then
+      echo "RQ worker is running (PID: $PID)"
+    else
+      echo "RQ worker is not running"
+    fi
+  else
+    echo "RQ worker is not running"
   fi
 }
 
 netbox-shell() {
-  (cd /opt/netbox/netbox && source /opt/netbox/venv/bin/activate && python manage.py shell)
+  cd /opt/netbox/netbox && source /opt/netbox/venv/bin/activate && python manage.py shell
 }
 
 netbox-test() {
-  (cd /opt/netbox/netbox && source /opt/netbox/venv/bin/activate && python manage.py test netbox_data_import "$@")
+  cd /opt/netbox/netbox && source /opt/netbox/venv/bin/activate && python manage.py test netbox_data_import "$@"
 }
 
 netbox-manage() {
-  (cd /opt/netbox/netbox && source /opt/netbox/venv/bin/activate && python manage.py "$@")
+  cd /opt/netbox/netbox && source /opt/netbox/venv/bin/activate && python manage.py "$@"
 }
 
 plugin-install() {
-  (cd "$PLUGIN_DIR" && uv pip install -e .)
+  cd "$PLUGIN_DIR" || return 1
+  if command -v uv >/dev/null 2>&1; then
+    uv pip install -e .
+  else
+    pip install -e .
+  fi
 }
 
-ruff-check() {
-  (cd "$PLUGIN_DIR" && ruff check .)
+plugins-install() {
+  if [ -f "$PLUGIN_DIR/.devcontainer/extra-requirements.txt" ]; then
+    source /opt/netbox/venv/bin/activate && pip install -r "$PLUGIN_DIR/.devcontainer/extra-requirements.txt"
+  else
+    echo "No .devcontainer/extra-requirements.txt found"
+  fi
 }
 
-ruff-format() {
-  (cd "$PLUGIN_DIR" && ruff format .)
+ruff-check() { cd "$PLUGIN_DIR" && command ruff check .; }
+ruff-format() { cd "$PLUGIN_DIR" && command ruff format .; }
+ruff-fix()    { cd "$PLUGIN_DIR" && command ruff check --fix .; }
+
+diagnose() { "$PLUGIN_DIR/.devcontainer/scripts/diagnose.sh"; }
+
+# RQ job inspection commands
+rq-stats() {
+  cd /opt/netbox/netbox && source /opt/netbox/venv/bin/activate && python manage.py rqstats
 }
 
-ruff-fix() {
-  (cd "$PLUGIN_DIR" && ruff check --fix .)
+rq-jobs() {
+  cd /opt/netbox/netbox && source /opt/netbox/venv/bin/activate && python manage.py shell -c \
+    "from django_rq import get_queue; q = get_queue('default'); print(f'Jobs in queue: {len(q)}'); [print(f'  {job.id[:8]}: {job.func_name} - {job.get_status()}') for job in q.jobs[:10]]"
 }
 
-diagnose() {
-  "$PLUGIN_DIR/.devcontainer/scripts/diagnose.sh"
+rq-failed() {
+  cd /opt/netbox/netbox && source /opt/netbox/venv/bin/activate && python manage.py shell -c \
+    "from django_rq import get_failed_queue; q = get_failed_queue(); print(f'Failed jobs: {len(q)}'); [print(f'  {job.id[:8]}: {job.func_name}') for job in q.jobs[:10]]"
 }
 
+rq-recent() {
+  cd /opt/netbox/netbox && source /opt/netbox/venv/bin/activate && python manage.py shell -c \
+    "from core.models import Job; jobs = Job.objects.all().order_by('-created')[:10]; [print(f'{j.id}: {j.name[:50]} - {getattr(j.status, \"value\", j.status)} ({j.user})') for j in jobs]"
+}
+
+# Help
 dev-help() {
-  echo "🎯 NetBox Interface Name Rules Plugin Development Commands:"
+  echo "🎯 NetBox Data Import Plugin Development Commands:"
   echo ""
   echo "📊 NetBox Server Management:"
-  echo "  netbox-run-bg       Start NetBox in background"
-  echo "  netbox-run          Start NetBox in foreground"
-  echo "  netbox-stop         Stop NetBox"
-  echo "  netbox-restart      Restart NetBox"
-  echo "  netbox-reload       Reinstall plugin and restart"
-  echo "  netbox-status       Check if NetBox is running"
-  echo "  netbox-logs         View NetBox server logs"
+  echo "  netbox-run-bg       : Start NetBox in background"
+  echo "  netbox-run          : Start NetBox in foreground (for debugging)"
+  echo "  netbox-stop         : Stop NetBox and RQ worker"
+  echo "  netbox-restart      : Restart NetBox and RQ worker"
+  echo "  netbox-reload       : Reinstall plugin and restart NetBox"
+  echo "  netbox-status       : Check if NetBox and RQ worker are running"
+  echo "  netbox-logs         : View NetBox server logs"
+  echo ""
+  echo "⚙️  Background Jobs (RQ Worker):"
+  echo "  rq-status           : Check if RQ worker is running"
+  echo "  rq-logs             : View RQ worker logs"
+  echo "  rq-stats            : Show RQ queue statistics"
+  echo "  rq-jobs             : List jobs in default queue"
+  echo "  rq-failed           : List failed jobs"
+  echo "  rq-recent           : Show recent NetBox jobs"
   echo ""
   echo "🛠️  Development Tools:"
-  echo "  netbox-shell        Open NetBox Django shell"
-  echo "  netbox-test         Run plugin tests"
-  echo "  netbox-manage CMD   Run Django management commands"
-  echo "  plugin-install      Reinstall plugin in dev mode"
+  echo "  netbox-shell        : Open NetBox Django shell"
+  echo "  netbox-test         : Run plugin tests"
+  echo "  netbox-manage       : Run Django management commands"
+  echo "  plugin-install      : Reinstall plugin in development mode"
   echo ""
   echo "🧹 Code Quality:"
-  echo "  ruff-check          Check code with Ruff"
-  echo "  ruff-format         Format code with Ruff"
-  echo "  ruff-fix            Auto-fix code issues"
+  echo "  ruff-check          : Check code with Ruff"
+  echo "  ruff-format         : Format code with Ruff"
+  echo "  ruff-fix            : Auto-fix code issues with Ruff"
   echo ""
   echo "🔎 Diagnostics:"
-  echo "  diagnose            Run startup diagnostics"
-  echo "  dev-help            Show this help message"
+  echo "  diagnose            : Run startup diagnostics"
+  echo "  dev-help            : Show this help message"
   echo ""
-  echo "📖 NetBox at: http://localhost:8000 (admin/admin)"
+  echo "📖 NetBox available at: http://localhost:8000 (admin/admin)"
 }
 
-echo "✅ Functions loaded! Type 'dev-help' for available commands."
+echo "✅ Dev helpers loaded! Try: rq-status, rq-stats, rq-recent, dev-help"

--- a/.devcontainer/scripts/load-aliases.sh
+++ b/.devcontainer/scripts/load-aliases.sh
@@ -225,7 +225,7 @@ dev-help() {
   echo "  diagnose            : Run startup diagnostics"
   echo "  dev-help            : Show this help message"
   echo ""
-  echo "📖 NetBox available at: http://localhost:8000 (${SUPERUSER_NAME:-admin}/${SUPERUSER_PASSWORD:-admin})"
+  echo "📖 NetBox available at: http://localhost:8000 (user: ${SUPERUSER_NAME:-admin}, password: see \$SUPERUSER_PASSWORD)"
 }
 
 echo "✅ Dev helpers loaded! Try: rq-status, rq-stats, rq-recent, dev-help"

--- a/.devcontainer/scripts/load-aliases.sh
+++ b/.devcontainer/scripts/load-aliases.sh
@@ -92,18 +92,8 @@ netbox-reload() {
 alias netbox-logs="tail -f /tmp/netbox.log"
 alias rq-logs="tail -f /tmp/rqworker.log"
 
-netbox-status() {
+_check_rq_status() {
   local PID
-  if [ -f /tmp/netbox.pid ]; then
-    PID=$(cat /tmp/netbox.pid 2>/dev/null)
-    if [ -n "$PID" ] && is_expected_pid "$PID" "manage\.py runserver.*8000"; then
-      echo "NetBox is running (PID: $PID)"
-    else
-      echo "NetBox is not running"
-    fi
-  else
-    echo "NetBox is not running"
-  fi
   if [ -f /tmp/rqworker.pid ]; then
     PID=$(cat /tmp/rqworker.pid 2>/dev/null)
     if [ -n "$PID" ] && is_expected_pid "$PID" "manage\.py rqworker"; then
@@ -116,18 +106,23 @@ netbox-status() {
   fi
 }
 
-rq-status() {
+netbox-status() {
   local PID
-  if [ -f /tmp/rqworker.pid ]; then
-    PID=$(cat /tmp/rqworker.pid 2>/dev/null)
-    if [ -n "$PID" ] && is_expected_pid "$PID" "manage\.py rqworker"; then
-      echo "RQ worker is running (PID: $PID)"
+  if [ -f /tmp/netbox.pid ]; then
+    PID=$(cat /tmp/netbox.pid 2>/dev/null)
+    if [ -n "$PID" ] && is_expected_pid "$PID" "manage\.py runserver.*8000"; then
+      echo "NetBox is running (PID: $PID)"
     else
-      echo "RQ worker is not running"
+      echo "NetBox is not running"
     fi
   else
-    echo "RQ worker is not running"
+    echo "NetBox is not running"
   fi
+  _check_rq_status
+}
+
+rq-status() {
+  _check_rq_status
 }
 
 netbox-shell() {

--- a/.devcontainer/scripts/load-aliases.sh
+++ b/.devcontainer/scripts/load-aliases.sh
@@ -80,6 +80,7 @@ netbox-restart() {
 
 netbox-reload() {
   cd "$PLUGIN_DIR" || return 1
+  source /opt/netbox/venv/bin/activate
   if command -v uv >/dev/null 2>&1; then
     uv pip install -e . || return 1
   else
@@ -143,6 +144,7 @@ netbox-manage() {
 
 plugin-install() {
   cd "$PLUGIN_DIR" || return 1
+  source /opt/netbox/venv/bin/activate
   if command -v uv >/dev/null 2>&1; then
     uv pip install -e .
   else

--- a/.devcontainer/scripts/load-aliases.sh
+++ b/.devcontainer/scripts/load-aliases.sh
@@ -152,7 +152,12 @@ plugin-install() {
 
 plugins-install() {
   if [ -f "$PLUGIN_DIR/.devcontainer/extra-requirements.txt" ]; then
-    source /opt/netbox/venv/bin/activate && pip install -r "$PLUGIN_DIR/.devcontainer/extra-requirements.txt"
+    source /opt/netbox/venv/bin/activate
+    if command -v uv >/dev/null 2>&1; then
+      uv pip install -r "$PLUGIN_DIR/.devcontainer/extra-requirements.txt"
+    else
+      pip install -r "$PLUGIN_DIR/.devcontainer/extra-requirements.txt"
+    fi
   else
     echo "No .devcontainer/extra-requirements.txt found"
   fi
@@ -220,7 +225,7 @@ dev-help() {
   echo "  diagnose            : Run startup diagnostics"
   echo "  dev-help            : Show this help message"
   echo ""
-  echo "📖 NetBox available at: http://localhost:8000 (admin/admin)"
+  echo "📖 NetBox available at: http://localhost:8000 (${SUPERUSER_NAME:-admin}/${SUPERUSER_PASSWORD:-admin})"
 }
 
 echo "✅ Dev helpers loaded! Try: rq-status, rq-stats, rq-recent, dev-help"

--- a/.devcontainer/scripts/load-aliases.sh
+++ b/.devcontainer/scripts/load-aliases.sh
@@ -34,9 +34,9 @@ netbox-run()    { "$PLUGIN_DIR/.devcontainer/scripts/start-netbox.sh"; }
 
 # Robust stop command that kills both tracked and orphaned processes
 netbox-stop() {
+  local PID ORPHAN_COUNT
   echo "🛑 Stopping NetBox and RQ workers..."
   if [ -f /tmp/netbox.pid ]; then
-    local PID
     PID=$(cat /tmp/netbox.pid 2>/dev/null)
     if [ -n "$PID" ] && kill -0 "$PID" 2>/dev/null; then
       if is_expected_pid "$PID" "manage\.py runserver.*8000"; then
@@ -49,7 +49,6 @@ netbox-stop() {
     rm -f /tmp/netbox.pid
   fi
   if [ -f /tmp/rqworker.pid ]; then
-    local PID
     PID=$(cat /tmp/rqworker.pid 2>/dev/null)
     if [ -n "$PID" ] && kill -0 "$PID" 2>/dev/null; then
       if is_expected_pid "$PID" "manage\.py rqworker"; then
@@ -62,7 +61,6 @@ netbox-stop() {
     rm -f /tmp/rqworker.pid
   fi
   if pgrep -f "manage\.py rqworker" >/dev/null 2>&1; then
-    local ORPHAN_COUNT
     ORPHAN_COUNT=$(pgrep -cf "manage\.py rqworker" 2>/dev/null || echo 0)
     graceful_kill_pattern "manage\.py rqworker"
     echo "   Killed $ORPHAN_COUNT orphaned RQ worker(s)"
@@ -98,11 +96,14 @@ _check_rq_status() {
     PID=$(cat /tmp/rqworker.pid 2>/dev/null)
     if [ -n "$PID" ] && is_expected_pid "$PID" "manage\.py rqworker"; then
       echo "RQ worker is running (PID: $PID)"
+      return 0
     else
       echo "RQ worker is not running"
+      return 1
     fi
   else
     echo "RQ worker is not running"
+    return 1
   fi
 }
 
@@ -141,9 +142,9 @@ plugin-install() {
   cd "$PLUGIN_DIR" || return 1
   source /opt/netbox/venv/bin/activate || return 1
   if command -v uv >/dev/null 2>&1; then
-    uv pip install -e .
+    uv pip install -e . || return 1
   else
-    pip install -e .
+    pip install -e . || return 1
   fi
 }
 
@@ -151,9 +152,9 @@ plugins-install() {
   if [ -f "$PLUGIN_DIR/.devcontainer/extra-requirements.txt" ]; then
     source /opt/netbox/venv/bin/activate || return 1
     if command -v uv >/dev/null 2>&1; then
-      uv pip install -r "$PLUGIN_DIR/.devcontainer/extra-requirements.txt"
+      uv pip install -r "$PLUGIN_DIR/.devcontainer/extra-requirements.txt" || return 1
     else
-      pip install -r "$PLUGIN_DIR/.devcontainer/extra-requirements.txt"
+      pip install -r "$PLUGIN_DIR/.devcontainer/extra-requirements.txt" || return 1
     fi
   else
     echo "No .devcontainer/extra-requirements.txt found"

--- a/.devcontainer/scripts/process-helpers.sh
+++ b/.devcontainer/scripts/process-helpers.sh
@@ -8,6 +8,12 @@
 graceful_kill_pid() {
   local pid="$1"
   [ -z "$pid" ] && return 1
+  # Reject non-positive-integer PIDs to prevent accidental group kills
+  case "$pid" in
+    ''|*[!0-9]*) echo "graceful_kill_pid: invalid PID '$pid'" >&2; return 1 ;;
+  esac
+  [ "$pid" -le 0 ] 2>/dev/null && { echo "graceful_kill_pid: PID must be > 0" >&2; return 1; }
+  kill -0 "$pid" 2>/dev/null || return 1
   kill -15 "$pid" 2>/dev/null || true
   sleep 2
   kill -0 "$pid" 2>/dev/null && kill -9 "$pid" 2>/dev/null || true

--- a/.devcontainer/scripts/process-helpers.sh
+++ b/.devcontainer/scripts/process-helpers.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2025 Marcin Zieba <marcinpsk@gmail.com>
+# Shared process management helpers.
+# Sourced by load-aliases.sh and start-netbox.sh.
+
+# Graceful termination: SIGTERM, wait, then SIGKILL if still alive.
+graceful_kill_pid() {
+  local pid="$1"
+  kill -15 "$pid" 2>/dev/null || true
+  sleep 2
+  kill -0 "$pid" 2>/dev/null && kill -9 "$pid" 2>/dev/null || true
+}
+
+graceful_kill_pattern() {
+  local pattern="$1"
+  pkill -15 -f "$pattern" 2>/dev/null || true
+  sleep 2
+  pgrep -f "$pattern" >/dev/null 2>&1 && pkill -9 -f "$pattern" 2>/dev/null || true
+}
+
+# Verify a PID matches the expected process before killing it
+is_expected_pid() {
+  local pid="$1" pattern="$2"
+  ps -p "$pid" -o args= 2>/dev/null | grep -Eq "$pattern"
+}

--- a/.devcontainer/scripts/process-helpers.sh
+++ b/.devcontainer/scripts/process-helpers.sh
@@ -7,6 +7,7 @@
 # Graceful termination: SIGTERM, wait, then SIGKILL if still alive.
 graceful_kill_pid() {
   local pid="$1"
+  [ -z "$pid" ] && return 1
   kill -15 "$pid" 2>/dev/null || true
   sleep 2
   kill -0 "$pid" 2>/dev/null && kill -9 "$pid" 2>/dev/null || true
@@ -14,6 +15,7 @@ graceful_kill_pid() {
 
 graceful_kill_pattern() {
   local pattern="$1"
+  [ -z "$pattern" ] && { echo "graceful_kill_pattern: empty pattern, refusing to kill" >&2; return 1; }
   pkill -15 -f "$pattern" 2>/dev/null || true
   sleep 2
   pgrep -f "$pattern" >/dev/null 2>&1 && pkill -9 -f "$pattern" 2>/dev/null || true
@@ -22,5 +24,6 @@ graceful_kill_pattern() {
 # Verify a PID matches the expected process before killing it
 is_expected_pid() {
   local pid="$1" pattern="$2"
+  [ -z "$pid" ] || [ -z "$pattern" ] && return 1
   ps -p "$pid" -o args= 2>/dev/null | grep -Eq "$pattern"
 }

--- a/.devcontainer/scripts/process-helpers.sh
+++ b/.devcontainer/scripts/process-helpers.sh
@@ -31,5 +31,9 @@ graceful_kill_pattern() {
 is_expected_pid() {
   local pid="$1" pattern="$2"
   [ -z "$pid" ] || [ -z "$pattern" ] && return 1
+  case "$pid" in
+    ''|*[!0-9]*) echo "is_expected_pid: invalid PID '$pid'" >&2; return 1 ;;
+  esac
+  [ "$pid" -le 0 ] 2>/dev/null && { echo "is_expected_pid: PID must be > 0" >&2; return 1; }
   ps -p "$pid" -o args= 2>/dev/null | grep -Eq "$pattern"
 }

--- a/.devcontainer/scripts/setup.sh
+++ b/.devcontainer/scripts/setup.sh
@@ -56,16 +56,18 @@ if [ -n "$HTTP_PROXY" ] || [ -n "$HTTPS_PROXY" ]; then
 
   if [ -n "$CA_BUNDLE_SRC" ]; then
     echo "🔐 Installing custom CA certificate from $CA_BUNDLE_SRC..."
-    cert_count=$(grep -c '-----BEGIN CERTIFICATE-----' "$CA_BUNDLE_SRC" 2>/dev/null || true)
+    cert_count=$(grep -c -- '-----BEGIN CERTIFICATE-----' "$CA_BUNDLE_SRC" 2>/dev/null || true)
     if [ "${cert_count:-0}" -eq 0 ]; then
       echo "  ⚠️  ca-bundle.crt does not contain any PEM certificate blocks; skipping CA install."
     else
       mkdir -p /usr/local/share/ca-certificates/proxy
       find /usr/local/share/ca-certificates/proxy -maxdepth 1 -name 'cert-*' -delete 2>/dev/null || true
+      set +e
       csplit -z -f /usr/local/share/ca-certificates/proxy/cert- \
         "$CA_BUNDLE_SRC" '/-----BEGIN CERTIFICATE-----/' '{*}' \
         >/dev/null 2>&1
       CSPLIT_STATUS=$?
+      set -e
       if [ "$CSPLIT_STATUS" -ne 0 ]; then
         echo "  ⚠️  Failed to split ca-bundle.crt (csplit exit code: $CSPLIT_STATUS). Skipping CA install."
       elif compgen -G "/usr/local/share/ca-certificates/proxy/cert-*" > /dev/null; then

--- a/.devcontainer/scripts/setup.sh
+++ b/.devcontainer/scripts/setup.sh
@@ -4,12 +4,19 @@
 set -e
 
 PLUGIN_NAME="netbox_data_import"
-PLUGIN_DISPLAY="Interface Name Rules"
+PLUGIN_DISPLAY="Data Import"
 
 echo "🚀 Setting up NetBox ${PLUGIN_DISPLAY} Plugin development environment..."
 echo "📍 Current working directory: $(pwd)"
 NETBOX_VERSION=${NETBOX_VERSION:-"latest"}
 echo "📦 Using NetBox Docker image: netboxcommunity/netbox:${NETBOX_VERSION}"
+
+# Clean up empty CA bundle vars (Compose injects "" when host var is unset)
+for _ca_var in REQUESTS_CA_BUNDLE SSL_CERT_FILE CURL_CA_BUNDLE; do
+  _val="${!_ca_var}"
+  [ -z "$_val" ] && unset "$_ca_var"
+done
+unset _ca_var _val
 
 # Detect plugin workspace directory
 detect_plugin_workspace() {
@@ -49,17 +56,33 @@ if [ -n "$HTTP_PROXY" ] || [ -n "$HTTPS_PROXY" ]; then
 
   if [ -n "$CA_BUNDLE_SRC" ]; then
     echo "🔐 Installing custom CA certificate from $CA_BUNDLE_SRC..."
-    mkdir -p /usr/local/share/ca-certificates/proxy
-    find /usr/local/share/ca-certificates/proxy -maxdepth 1 -name 'cert-*' -delete 2>/dev/null || true
-    csplit -z -f /usr/local/share/ca-certificates/proxy/cert- "$CA_BUNDLE_SRC" '/-----BEGIN CERTIFICATE-----/' '{*}' >/dev/null 2>&1
-    for f in /usr/local/share/ca-certificates/proxy/cert-*; do mv "$f" "${f}.crt" 2>/dev/null || true; done
-    update-ca-certificates 2>/dev/null
+    cert_count=$(grep -c '-----BEGIN CERTIFICATE-----' "$CA_BUNDLE_SRC" 2>/dev/null || true)
+    if [ "${cert_count:-0}" -eq 0 ]; then
+      echo "  ⚠️  ca-bundle.crt does not contain any PEM certificate blocks; skipping CA install."
+    else
+      mkdir -p /usr/local/share/ca-certificates/proxy
+      find /usr/local/share/ca-certificates/proxy -maxdepth 1 -name 'cert-*' -delete 2>/dev/null || true
+      csplit -z -f /usr/local/share/ca-certificates/proxy/cert- \
+        "$CA_BUNDLE_SRC" '/-----BEGIN CERTIFICATE-----/' '{*}' \
+        >/dev/null 2>&1
+      CSPLIT_STATUS=$?
+      if [ "$CSPLIT_STATUS" -ne 0 ]; then
+        echo "  ⚠️  Failed to split ca-bundle.crt (csplit exit code: $CSPLIT_STATUS). Skipping CA install."
+      elif compgen -G "/usr/local/share/ca-certificates/proxy/cert-*" > /dev/null; then
+        for f in /usr/local/share/ca-certificates/proxy/cert-*; do
+          mv "$f" "${f}.crt" 2>/dev/null || true
+        done
+        update-ca-certificates 2>/dev/null
+        echo "  ✓ CA certificate installed into system trust store ($cert_count cert(s))"
+      else
+        echo "  ⚠️  No certificate fragments were generated from ca-bundle.crt; skipping CA install."
+      fi
+    fi
     export REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
     export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
     export CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
     export GIT_SSL_CAINFO=/etc/ssl/certs/ca-certificates.crt
     pip config set global.cert /etc/ssl/certs/ca-certificates.crt 2>/dev/null || true
-    echo "  ✓ CA certificate installed"
   fi
 fi
 
@@ -70,16 +93,17 @@ if [ ! -f "/opt/netbox/venv/bin/activate" ]; then
 fi
 source /opt/netbox/venv/bin/activate
 
-# Install uv if not available
-if ! command -v uv >/dev/null 2>&1; then
-  echo "🔧 Installing uv..."
-  pip install uv
+# Choose installer (uv if available, else pip)
+if command -v uv >/dev/null 2>&1; then
+  PIP_CMD="uv pip"
+else
+  PIP_CMD="pip"
 fi
 
 echo "🔧 Installing development dependencies..."
 apt-get update -qq
 apt-get install -y -qq net-tools git
-uv pip install pytest pytest-django ruff pre-commit
+$PIP_CMD install pytest pytest-django ruff pre-commit
 
 # Install GitHub CLI
 if ! command -v gh >/dev/null 2>&1; then
@@ -106,7 +130,7 @@ if [ -z "$PLUGIN_WS_DIR" ]; then
 fi
 echo "📂 Plugin workspace: $PLUGIN_WS_DIR"
 cd "$PLUGIN_WS_DIR"
-uv pip install -e .
+$PIP_CMD install -e .
 echo "✅ Installed $PLUGIN_NAME in editable mode"
 
 # Install extra plugins from config file
@@ -133,12 +157,12 @@ for p in getattr(m, 'EXTRA_PLUGINS', []):
     if [[ "$line" == pip:* ]]; then
       pkg="${line#pip:}"
       echo "  📦 Installing $pkg from PyPI..."
-      uv pip install "$pkg" || echo "  ⚠️  Failed to install $pkg"
+      $PIP_CMD install "$pkg" || echo "  ⚠️  Failed to install $pkg"
     elif [[ "$line" == editable:* ]]; then
       path="${line#editable:}"
       echo "  📦 Installing from $path (editable)..."
       if [ -d "$path" ]; then
-        uv pip install -e "$path" || echo "  ⚠️  Failed to install from $path"
+        $PIP_CMD install -e "$path" || echo "  ⚠️  Failed to install from $path"
       else
         echo "  ⚠️  Path $path not found (is the repo mounted?)"
       fi
@@ -210,15 +234,17 @@ echo "🗃️  Applying database migrations..."
 python manage.py migrate 2>&1 | grep -E "(Operations to perform|Running migrations|Apply all migrations|No migrations to apply|\s+Applying|\s+OK)" || true
 
 echo "🔐 Creating superuser (if not exists)..."
+echo "   Credentials are read from environment variables (see .devcontainer/.env)"
 python manage.py shell -c "
+import os
 from django.contrib.auth import get_user_model
 User = get_user_model()
-username = '${SUPERUSER_NAME:-admin}'
-email = '${SUPERUSER_EMAIL:-admin@example.com}'
-password = '${SUPERUSER_PASSWORD:-admin}'
+username = (os.environ.get('SUPERUSER_NAME') or '').strip() or 'admin'
+email = (os.environ.get('SUPERUSER_EMAIL') or '').strip() or 'admin@example.com'
+password = (os.environ.get('SUPERUSER_PASSWORD') or '').strip() or 'admin'
 if not User.objects.filter(username=username).exists():
     User.objects.create_superuser(username, email, password)
-    print(f'Created superuser: {username}/{password}')
+    print(f'Created superuser: {username}')
 else:
     print(f'Superuser {username} already exists')
 " 2>/dev/null || true

--- a/.devcontainer/scripts/start-netbox.sh
+++ b/.devcontainer/scripts/start-netbox.sh
@@ -115,10 +115,9 @@ else
   echo ""
   # Gracefully shut down the background RQ worker when this script exits
   _cleanup_rq() {
-    kill -15 "$RQ_PID" 2>/dev/null || true
-    local i=0
-    while kill -0 "$RQ_PID" 2>/dev/null && [ $i -lt 5 ]; do sleep 1; i=$((i+1)); done
-    kill -0 "$RQ_PID" 2>/dev/null && kill -9 "$RQ_PID" 2>/dev/null || true
+    if is_expected_pid "$RQ_PID" "manage\.py rqworker"; then
+      graceful_kill_pid "$RQ_PID"
+    fi
     rm -f /tmp/rqworker.pid
   }
   trap '_cleanup_rq' EXIT INT TERM

--- a/.devcontainer/scripts/start-netbox.sh
+++ b/.devcontainer/scripts/start-netbox.sh
@@ -110,6 +110,16 @@ if [ "$BACKGROUND" = true ]; then
   sleep 0.3
   if ! kill -0 "$NETBOX_PID" 2>/dev/null; then
     echo "ERROR: NetBox failed to start; check /tmp/netbox.log" >&2
+    # Clean up the already-started RQ worker before exiting
+    if [ -f /tmp/rqworker.pid ]; then
+      _rq_cleanup_pid=$(cat /tmp/rqworker.pid 2>/dev/null)
+      if [ -n "$_rq_cleanup_pid" ]; then
+        kill "$_rq_cleanup_pid" 2>/dev/null
+        sleep 0.5
+        kill -0 "$_rq_cleanup_pid" 2>/dev/null && kill -9 "$_rq_cleanup_pid" 2>/dev/null
+      fi
+      rm -f /tmp/rqworker.pid
+    fi
     exit 1
   fi
   echo $NETBOX_PID > /tmp/netbox.pid

--- a/.devcontainer/scripts/start-netbox.sh
+++ b/.devcontainer/scripts/start-netbox.sh
@@ -10,32 +10,78 @@ fi
 
 echo "🌐 Starting NetBox development server..."
 
+# Set required environment variables
 export DEBUG="${DEBUG:-True}"
 
+# Detect Codespaces and set access URL
 if [ "$CODESPACES" = "true" ] && [ -n "$CODESPACE_NAME" ]; then
   GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN="${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN:-app.github.dev}"
   ACCESS_URL="https://${CODESPACE_NAME}-8000.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}"
+  echo "🔗 GitHub Codespaces detected"
 else
   ACCESS_URL="http://localhost:8000"
 fi
 
-# Clean up orphaned processes
-echo "🧹 Cleaning up orphaned processes..."
-if pgrep -f "python.*runserver.*8000" >/dev/null 2>&1; then
-  pkill -9 -f "python.*runserver.*8000" 2>/dev/null
-  sleep 1
+# Load shared process management helpers
+if ! source "$(dirname "$0")/process-helpers.sh"; then
+  echo "ERROR: Failed to load process-helpers.sh" >&2
+  exit 1
 fi
 
+# Kill any orphaned processes (not tracked by PID file)
+echo "🧹 Cleaning up orphaned processes..."
+if pgrep -f "python.*rqworker" >/dev/null 2>&1; then
+  echo "   Found orphaned RQ workers, killing..."
+  graceful_kill_pattern "python.*rqworker"
+fi
+
+if pgrep -f "python.*runserver.*8000" >/dev/null 2>&1; then
+  echo "   Found orphaned NetBox servers, killing..."
+  graceful_kill_pattern "python.*runserver.*8000"
+fi
+
+# Stop any tracked processes from PID files
 if [ -f /tmp/netbox.pid ]; then
   OLD_PID=$(cat /tmp/netbox.pid 2>/dev/null)
   if [ -n "$OLD_PID" ] && kill -0 "$OLD_PID" 2>/dev/null; then
-    kill "$OLD_PID" 2>/dev/null || kill -9 "$OLD_PID" 2>/dev/null
+    if is_expected_pid "$OLD_PID" "python.*runserver.*8000"; then
+      graceful_kill_pid "$OLD_PID"
+    else
+      echo "⚠️  Skipping stale /tmp/netbox.pid (PID $OLD_PID is not NetBox runserver)"
+    fi
   fi
   rm -f /tmp/netbox.pid
 fi
 
+if [ -f /tmp/rqworker.pid ]; then
+  OLD_PID=$(cat /tmp/rqworker.pid 2>/dev/null)
+  if [ -n "$OLD_PID" ] && kill -0 "$OLD_PID" 2>/dev/null; then
+    if is_expected_pid "$OLD_PID" "python.*rqworker"; then
+      graceful_kill_pid "$OLD_PID"
+    else
+      echo "⚠️  Skipping stale /tmp/rqworker.pid (PID $OLD_PID is not rqworker)"
+    fi
+  fi
+  rm -f /tmp/rqworker.pid
+fi
+
+# Activate NetBox virtual environment
 source /opt/netbox/venv/bin/activate
+
+# Navigate to NetBox directory
 cd /opt/netbox/netbox
+
+# Start RQ worker in background
+echo "⚙️  Starting RQ worker..."
+(
+  source /opt/netbox/venv/bin/activate
+  cd /opt/netbox/netbox
+  python manage.py rqworker --verbosity=1
+) > /tmp/rqworker.log 2>&1 &
+
+RQ_PID=$!
+echo $RQ_PID > /tmp/rqworker.pid
+echo "✅ RQ worker started (PID: $RQ_PID)"
 
 if [ "$BACKGROUND" = true ]; then
   echo "🚀 Starting NetBox in background"
@@ -50,11 +96,13 @@ if [ "$BACKGROUND" = true ]; then
   echo $NETBOX_PID > /tmp/netbox.pid
   echo "✅ NetBox started in background (PID: $NETBOX_PID)"
   echo "📍 Access NetBox at: $ACCESS_URL"
+  echo "💡 If clicking the URL opens 0.0.0.0:8000, manually type: localhost:8000"
   echo "📄 View logs with: netbox-logs"
-  echo "🛑 Stop with: netbox-stop"
+  echo "🛑 Stop NetBox with: netbox-stop"
 else
   echo "🌍 Starting NetBox in foreground"
   echo "📍 Access NetBox at: $ACCESS_URL"
+  echo "💡 If clicking the URL opens 0.0.0.0:8000, manually type: localhost:8000"
   echo ""
   python manage.py runserver 0.0.0.0:8000
 fi

--- a/.devcontainer/scripts/start-netbox.sh
+++ b/.devcontainer/scripts/start-netbox.sh
@@ -86,6 +86,11 @@ echo "⚙️  Starting RQ worker..."
 ) > /tmp/rqworker.log 2>&1 &
 
 RQ_PID=$!
+sleep 0.3
+if ! kill -0 "$RQ_PID" 2>/dev/null; then
+  echo "ERROR: RQ worker failed to start; check /tmp/rqworker.log" >&2
+  exit 1
+fi
 echo $RQ_PID > /tmp/rqworker.pid
 echo "✅ RQ worker started (PID: $RQ_PID)"
 
@@ -102,6 +107,11 @@ if [ "$BACKGROUND" = true ]; then
   ) > /tmp/netbox.log 2>&1 &
 
   NETBOX_PID=$!
+  sleep 0.3
+  if ! kill -0 "$NETBOX_PID" 2>/dev/null; then
+    echo "ERROR: NetBox failed to start; check /tmp/netbox.log" >&2
+    exit 1
+  fi
   echo $NETBOX_PID > /tmp/netbox.pid
   echo "✅ NetBox started in background (PID: $NETBOX_PID)"
   echo "📍 Access NetBox at: $ACCESS_URL"

--- a/.devcontainer/scripts/start-netbox.sh
+++ b/.devcontainer/scripts/start-netbox.sh
@@ -69,13 +69,19 @@ fi
 source /opt/netbox/venv/bin/activate
 
 # Navigate to NetBox directory
-cd /opt/netbox/netbox
+if ! cd /opt/netbox/netbox; then
+  echo "ERROR: Failed to cd into /opt/netbox/netbox" >&2
+  exit 1
+fi
 
 # Start RQ worker in background
 echo "⚙️  Starting RQ worker..."
 (
   source /opt/netbox/venv/bin/activate
-  cd /opt/netbox/netbox
+  if ! cd /opt/netbox/netbox; then
+    echo "ERROR: RQ worker subshell: failed to cd into /opt/netbox/netbox" >&2
+    exit 1
+  fi
   python manage.py rqworker --verbosity=1
 ) > /tmp/rqworker.log 2>&1 &
 
@@ -88,7 +94,10 @@ if [ "$BACKGROUND" = true ]; then
   (
     export DEBUG="${DEBUG:-True}"
     source /opt/netbox/venv/bin/activate
-    cd /opt/netbox/netbox
+    if ! cd /opt/netbox/netbox; then
+      echo "ERROR: NetBox subshell: failed to cd into /opt/netbox/netbox" >&2
+      exit 1
+    fi
     python manage.py runserver 0.0.0.0:8000 --verbosity=0
   ) > /tmp/netbox.log 2>&1 &
 

--- a/.devcontainer/scripts/start-netbox.sh
+++ b/.devcontainer/scripts/start-netbox.sh
@@ -66,7 +66,7 @@ if [ -f /tmp/rqworker.pid ]; then
 fi
 
 # Activate NetBox virtual environment
-source /opt/netbox/venv/bin/activate
+source /opt/netbox/venv/bin/activate || { echo "ERROR: Failed to activate venv at /opt/netbox/venv" >&2; exit 1; }
 
 # Navigate to NetBox directory
 if ! cd /opt/netbox/netbox; then
@@ -77,7 +77,7 @@ fi
 # Start RQ worker in background
 echo "⚙️  Starting RQ worker..."
 (
-  source /opt/netbox/venv/bin/activate
+  source /opt/netbox/venv/bin/activate || { echo "ERROR: RQ worker subshell: failed to activate venv" >&2; exit 1; }
   if ! cd /opt/netbox/netbox; then
     echo "ERROR: RQ worker subshell: failed to cd into /opt/netbox/netbox" >&2
     exit 1
@@ -93,7 +93,7 @@ if [ "$BACKGROUND" = true ]; then
   echo "🚀 Starting NetBox in background"
   (
     export DEBUG="${DEBUG:-True}"
-    source /opt/netbox/venv/bin/activate
+    source /opt/netbox/venv/bin/activate || { echo "ERROR: NetBox subshell: failed to activate venv" >&2; exit 1; }
     if ! cd /opt/netbox/netbox; then
       echo "ERROR: NetBox subshell: failed to cd into /opt/netbox/netbox" >&2
       exit 1
@@ -113,7 +113,14 @@ else
   echo "📍 Access NetBox at: $ACCESS_URL"
   echo "💡 If clicking the URL opens 0.0.0.0:8000, manually type: localhost:8000"
   echo ""
-  # Kill the background RQ worker when this script exits (Ctrl-C / SIGTERM)
-  trap 'kill "$RQ_PID" 2>/dev/null; rm -f /tmp/rqworker.pid' EXIT INT TERM
+  # Gracefully shut down the background RQ worker when this script exits
+  _cleanup_rq() {
+    kill -15 "$RQ_PID" 2>/dev/null || true
+    local i=0
+    while kill -0 "$RQ_PID" 2>/dev/null && [ $i -lt 5 ]; do sleep 1; i=$((i+1)); done
+    kill -0 "$RQ_PID" 2>/dev/null && kill -9 "$RQ_PID" 2>/dev/null || true
+    rm -f /tmp/rqworker.pid
+  }
+  trap '_cleanup_rq' EXIT INT TERM
   python manage.py runserver 0.0.0.0:8000
 fi

--- a/.devcontainer/scripts/start-netbox.sh
+++ b/.devcontainer/scripts/start-netbox.sh
@@ -30,21 +30,21 @@ fi
 
 # Kill any orphaned processes (not tracked by PID file)
 echo "🧹 Cleaning up orphaned processes..."
-if pgrep -f "python.*rqworker" >/dev/null 2>&1; then
+if pgrep -f "manage\.py rqworker" >/dev/null 2>&1; then
   echo "   Found orphaned RQ workers, killing..."
-  graceful_kill_pattern "python.*rqworker"
+  graceful_kill_pattern "manage\.py rqworker"
 fi
 
-if pgrep -f "python.*runserver.*8000" >/dev/null 2>&1; then
+if pgrep -f "manage\.py runserver.*8000" >/dev/null 2>&1; then
   echo "   Found orphaned NetBox servers, killing..."
-  graceful_kill_pattern "python.*runserver.*8000"
+  graceful_kill_pattern "manage\.py runserver.*8000"
 fi
 
 # Stop any tracked processes from PID files
 if [ -f /tmp/netbox.pid ]; then
   OLD_PID=$(cat /tmp/netbox.pid 2>/dev/null)
   if [ -n "$OLD_PID" ] && kill -0 "$OLD_PID" 2>/dev/null; then
-    if is_expected_pid "$OLD_PID" "python.*runserver.*8000"; then
+    if is_expected_pid "$OLD_PID" "manage\.py runserver.*8000"; then
       graceful_kill_pid "$OLD_PID"
     else
       echo "⚠️  Skipping stale /tmp/netbox.pid (PID $OLD_PID is not NetBox runserver)"
@@ -56,7 +56,7 @@ fi
 if [ -f /tmp/rqworker.pid ]; then
   OLD_PID=$(cat /tmp/rqworker.pid 2>/dev/null)
   if [ -n "$OLD_PID" ] && kill -0 "$OLD_PID" 2>/dev/null; then
-    if is_expected_pid "$OLD_PID" "python.*rqworker"; then
+    if is_expected_pid "$OLD_PID" "manage\.py rqworker"; then
       graceful_kill_pid "$OLD_PID"
     else
       echo "⚠️  Skipping stale /tmp/rqworker.pid (PID $OLD_PID is not rqworker)"
@@ -113,5 +113,7 @@ else
   echo "📍 Access NetBox at: $ACCESS_URL"
   echo "💡 If clicking the URL opens 0.0.0.0:8000, manually type: localhost:8000"
   echo ""
+  # Kill the background RQ worker when this script exits (Ctrl-C / SIGTERM)
+  trap 'kill "$RQ_PID" 2>/dev/null; rm -f /tmp/rqworker.pid' EXIT INT TERM
   python manage.py runserver 0.0.0.0:8000
 fi

--- a/.devcontainer/scripts/start-netbox.sh
+++ b/.devcontainer/scripts/start-netbox.sh
@@ -113,10 +113,8 @@ if [ "$BACKGROUND" = true ]; then
     # Clean up the already-started RQ worker before exiting
     if [ -f /tmp/rqworker.pid ]; then
       _rq_cleanup_pid=$(cat /tmp/rqworker.pid 2>/dev/null)
-      if [ -n "$_rq_cleanup_pid" ]; then
-        kill "$_rq_cleanup_pid" 2>/dev/null
-        sleep 0.5
-        kill -0 "$_rq_cleanup_pid" 2>/dev/null && kill -9 "$_rq_cleanup_pid" 2>/dev/null
+      if [ -n "$_rq_cleanup_pid" ] && is_expected_pid "$_rq_cleanup_pid" "manage\.py rqworker"; then
+        graceful_kill_pid "$_rq_cleanup_pid"
       fi
       rm -f /tmp/rqworker.pid
     fi

--- a/.devcontainer/scripts/welcome.sh
+++ b/.devcontainer/scripts/welcome.sh
@@ -37,7 +37,7 @@ if [ -n "$CODESPACES" ]; then
   echo "   NetBox will be available via automatic port forwarding"
   echo "   Check the 'Ports' panel for the forwarded port labeled 'NetBox Web Interface'"
   if [ -n "$CODESPACE_NAME" ]; then
-    CODESPACE_URL="https://${CODESPACE_NAME}-8000.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN:-preview.app.github.dev}"
+    CODESPACE_URL="https://${CODESPACE_NAME}-8000.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN:-app.github.dev}"
     echo "   Expected URL: $CODESPACE_URL"
   fi
   echo "   💡 Click the link in the Ports panel or look for the 'Open in Browser' button"

--- a/.devcontainer/scripts/welcome.sh
+++ b/.devcontainer/scripts/welcome.sh
@@ -32,7 +32,7 @@ else
 fi
 
 echo ""
-if [ -n "$CODESPACES" ]; then
+if [ "$CODESPACES" = "true" ]; then
   echo "🌐 GitHub Codespaces Environment:"
   echo "   NetBox will be available via automatic port forwarding"
   echo "   Check the 'Ports' panel for the forwarded port labeled 'NetBox Web Interface'"

--- a/.devcontainer/scripts/welcome.sh
+++ b/.devcontainer/scripts/welcome.sh
@@ -2,39 +2,54 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2025 Marcin Zieba <marcinpsk@gmail.com>
 
-# Ensure aliases are available
+# Ensure aliases are available in the postAttach terminal session
 source "$(dirname "$0")/load-aliases.sh" 2>/dev/null
 
 echo ""
-echo "🎯 NetBox Interface Name Rules Plugin Development Environment"
+echo "🎯 NetBox Data Import Plugin Development Environment"
 
-if [ ! -f "/workspaces/netbox-data-import-plugin/.devcontainer/config/plugin-config.py" ]; then
+PLUGIN_WS_DIR="${PLUGIN_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+if [ ! -f "$PLUGIN_WS_DIR/.devcontainer/config/plugin-config.py" ]; then
   echo ""
   echo "⚠️  Plugin configuration not found: .devcontainer/config/plugin-config.py"
-  echo "   Create it: cp .devcontainer/config/plugin-config.py.example .devcontainer/config/plugin-config.py"
+  echo "   Create it first: cp .devcontainer/config/plugin-config.py.example .devcontainer/config/plugin-config.py"
 fi
 
+# Check GitHub CLI authentication status
 echo ""
 if command -v gh >/dev/null 2>&1; then
   if gh auth status >/dev/null 2>&1; then
     GH_USER=$(gh api user --jq '.login' 2>/dev/null || echo "unknown")
     echo "✅ GitHub authenticated as: $GH_USER"
+    echo "   Git is configured for GitHub operations"
   else
     echo "🔑 GitHub CLI available but not authenticated"
-    echo "   Run 'gh auth login' to authenticate"
+    echo "   Run 'gh auth login' to authenticate with GitHub"
+    echo "   This will automatically configure Git for pushing/pulling"
   fi
+else
+  echo "⚠️  GitHub CLI not available"
 fi
 
 echo ""
 if [ -n "$CODESPACES" ]; then
-  echo "🌐 GitHub Codespaces Environment"
+  echo "🌐 GitHub Codespaces Environment:"
+  echo "   NetBox will be available via automatic port forwarding"
+  echo "   Check the 'Ports' panel for the forwarded port labeled 'NetBox Web Interface'"
+  if [ -n "$CODESPACE_NAME" ]; then
+    CODESPACE_URL="https://${CODESPACE_NAME}-8000.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN:-preview.app.github.dev}"
+    echo "   Expected URL: $CODESPACE_URL"
+  fi
+  echo "   💡 Click the link in the Ports panel or look for the 'Open in Browser' button"
 else
-  echo "🖥️  Local Development Environment"
-  echo "   NetBox will be available at: http://localhost:8000"
+  echo "🖥️  Local Development Environment:"
+  echo "   NetBox will be available at: http://localhost:8000 (paste into your browser)"
 fi
 
 echo ""
 echo "🚀 Quick start:"
 echo "   • Type 'netbox-run' to start the development server"
+echo "   • Type 'netbox-restart' to restart NetBox (after config changes)"
 echo "   • Type 'dev-help' to see all available commands"
+echo "   • Edit code in the workspace - auto-reload is enabled"
 echo ""

--- a/.devcontainer/scripts/welcome.sh
+++ b/.devcontainer/scripts/welcome.sh
@@ -3,7 +3,10 @@
 # Copyright (C) 2025 Marcin Zieba <marcinpsk@gmail.com>
 
 # Ensure aliases are available in the postAttach terminal session
-source "$(dirname "$0")/load-aliases.sh" 2>/dev/null
+_ALIASES_OK=1
+if ! source "$(dirname "$0")/load-aliases.sh" 2>/dev/null; then
+  _ALIASES_OK=0
+fi
 
 echo ""
 echo "🎯 NetBox Data Import Plugin Development Environment"
@@ -52,4 +55,8 @@ echo "   • Type 'netbox-run' to start the development server"
 echo "   • Type 'netbox-restart' to restart NetBox (after config changes)"
 echo "   • Type 'dev-help' to see all available commands"
 echo "   • Edit code in the workspace - auto-reload is enabled"
+if [ "${_ALIASES_OK:-1}" = "0" ]; then
+  echo ""
+  echo "⚠️  Shell aliases failed to load — run commands via .devcontainer/scripts/ directly"
+fi
 echo ""

--- a/netbox_data_import/engine.py
+++ b/netbox_data_import/engine.py
@@ -389,7 +389,7 @@ def _pass1_ensure_types(rows, profile, class_role_map, result, dry_run):
     for row in rows:
         device_class = str(row.get("device_class", "")).strip()
         crm = class_role_map.get(device_class)
-        if crm and (crm.creates_rack or crm.ignore):
+        if crm is None or crm.creates_rack or crm.ignore:
             continue
 
         make = " ".join(str(row.get("make", "Unknown")).split()) or "Unknown"
@@ -777,13 +777,15 @@ def _write_device_row(
         tenant=tenant,
     )
     _store_source_id(device, profile, source_id)
+    _rack_label = rack_name if rack_name else "(no rack)"
+    _pos_label = f" U{position}" if position is not None else ""
     return RowResult(
         row_number=row["_row_number"],
         source_id=source_id,
         name=device_name,
         action="create",
         object_type="device",
-        detail=f"Created device '{device_name}' in {rack_name} U{position}",
+        detail=f"Created device '{device_name}' in {_rack_label}{_pos_label}",
         netbox_url=device.get_absolute_url(),
         rack_name=rack_name,
         extra_data={"source_make": make, "source_model": model, "asset_tag": asset_tag or ""},

--- a/netbox_data_import/engine.py
+++ b/netbox_data_import/engine.py
@@ -10,6 +10,7 @@ run_import(rows, profile, context, dry_run=True)  ->  ImportResult
 
 from __future__ import annotations
 
+import logging
 import re
 from dataclasses import dataclass, field
 from typing import Literal
@@ -19,6 +20,8 @@ from django.utils.text import slugify
 import openpyxl
 
 from .models import ImportProfile
+
+logger = logging.getLogger(__name__)
 
 
 class ParseError(Exception):
@@ -257,12 +260,6 @@ def _resolve_device_type_slugs(make: str, model: str, profile: ImportProfile) ->
 # ---------------------------------------------------------------------------
 
 # Value-translation maps (shared across passes)
-_SIDE_MAP = {
-    "front": None,  # filled lazily once DeviceFaceChoices is imported
-    "back": None,
-    "rear": None,
-}
-_AIRFLOW_MAP = {}
 _STATUS_MAP = {
     "live": "active",
     "production": "active",
@@ -570,7 +567,7 @@ def _find_existing_device(profile, source_id, site, device_name, serial, asset_t
 
     Returns (device, match_method) or (None, None).
     """
-    existing_match = profile.device_matches.filter(source_id=source_id).first()
+    existing_match = profile.device_matches.filter(source_id=source_id).first() if source_id else None
     matched_device = None
     match_method = None
     if existing_match:
@@ -584,15 +581,19 @@ def _find_existing_device(profile, source_id, site, device_name, serial, asset_t
         try:
             matched_device = Device.objects.get(serial=serial)
             match_method = "serial"
-        except (Device.DoesNotExist, Device.MultipleObjectsReturned):
+        except Device.DoesNotExist:
             pass
+        except Device.MultipleObjectsReturned:
+            logger.warning("Ambiguous serial match for serial=%r; skipping auto-match", serial)
 
     if matched_device is None and asset_tag:
         try:
             matched_device = Device.objects.get(asset_tag=asset_tag)
             match_method = "asset tag"
-        except (Device.DoesNotExist, Device.MultipleObjectsReturned):
+        except Device.DoesNotExist:
             pass
+        except Device.MultipleObjectsReturned:
+            logger.warning("Ambiguous asset_tag match for asset_tag=%r; skipping auto-match", asset_tag)
 
     return matched_device, match_method
 

--- a/netbox_data_import/engine.py
+++ b/netbox_data_import/engine.py
@@ -563,9 +563,12 @@ def _pass2_process_racks(rows, profile, site, location, tenant, class_role_map, 
 
 
 def _find_existing_device(profile, source_id, site, device_name, serial, asset_tag, Device):
-    """Look up a pre-existing NetBox device by source-ID link, serial, or asset_tag.
+    """Look up a pre-existing NetBox device by source-ID link, serial, asset_tag, or name.
 
     Returns (device, match_method) or (None, None).
+    Matching priority: source-ID link → serial → asset_tag → name.
+    When *site* is provided the name lookup is scoped to that site; without a
+    site the name is matched globally (any site).
     """
     existing_match = profile.device_matches.filter(source_id=source_id).first() if source_id else None
     matched_device = None
@@ -594,6 +597,18 @@ def _find_existing_device(profile, source_id, site, device_name, serial, asset_t
             pass
         except Device.MultipleObjectsReturned:
             logger.warning("Ambiguous asset_tag match for asset_tag=%r; skipping auto-match", asset_tag)
+
+    if matched_device is None and device_name:
+        name_filter = {"name": device_name}
+        if site is not None:
+            name_filter["site"] = site
+        try:
+            matched_device = Device.objects.get(**name_filter)
+            match_method = "name"
+        except Device.DoesNotExist:
+            pass
+        except Device.MultipleObjectsReturned:
+            logger.warning("Ambiguous name match for device_name=%r; skipping auto-match", device_name)
 
     return matched_device, match_method
 
@@ -631,7 +646,11 @@ def _preview_device_row(
         rack_label = rack_name if rack_name in rack_map else f"{rack_name} (not found)"
     else:
         rack_label = "(no rack)"
-    position = row.get("u_position")
+    raw_position = row.get("u_position")
+    try:
+        position = int(float(raw_position)) if raw_position is not None and str(raw_position).strip() != "" else None
+    except (TypeError, ValueError):
+        position = None
 
     try:
         Device.objects.get(site=site, name=device_name)
@@ -646,7 +665,8 @@ def _preview_device_row(
             detail = f"Matched to existing device '{matched_device.name}' (by {match_method})"
         else:
             action = "create"
-            detail = f"Would create device '{device_name}' in {rack_label} U{position}"
+            _pos_label = f" U{position}" if position is not None else ""
+            detail = f"Would create device '{device_name}' in {rack_label}{_pos_label}"
 
     return RowResult(
         row_number=row["_row_number"],

--- a/netbox_data_import/engine.py
+++ b/netbox_data_import/engine.py
@@ -145,7 +145,13 @@ def _apply_transform_rules(row_dict: dict, raw_row, raw_headers: dict, transform
         if raw_value is None:
             continue
         raw_str = str(raw_value).strip()
-        m = re.fullmatch(rule.pattern, raw_str)
+        try:
+            m = re.fullmatch(rule.pattern, raw_str)
+        except re.error as exc:
+            raise ParseError(
+                f"Invalid regex pattern '{rule.pattern}' in transform rule for column "
+                f"'{rule.source_column}' (value: {raw_str!r}): {exc}"
+            ) from exc
         if m and rule.group_1_target and len(m.groups()) >= 1:
             row_dict[rule.group_1_target] = m.group(1)
         if m and rule.group_2_target and len(m.groups()) >= 2:
@@ -291,7 +297,8 @@ def _ensure_manufacturer(mfg_slug, make, seen_manufacturers, profile, result, dr
         return
     seen_manufacturers.add(mfg_slug)
     if not dry_run:
-        Manufacturer.objects.get_or_create(slug=mfg_slug, defaults={"name": make})
+        if profile.create_missing_device_types:
+            Manufacturer.objects.get_or_create(slug=mfg_slug, defaults={"name": make})
     elif not Manufacturer.objects.filter(slug=mfg_slug).exists() and profile.create_missing_device_types:
         result.rows.append(
             RowResult(
@@ -631,7 +638,7 @@ def _preview_device_row(
             profile, source_id, site, device_name, serial, asset_tag, Device
         )
         if matched_device is not None:
-            action = "update"
+            action = "update" if profile.update_existing else "skip"
             detail = f"Matched to existing device '{matched_device.name}' (by {match_method})"
         else:
             action = "create"
@@ -701,20 +708,16 @@ def _write_device_row(
         )
 
     rack = rack_map.get(rack_name) if rack_name else None
+    if rack_name and rack is None:
+        rack = Rack.objects.filter(site=site, name=rack_name).first()
 
     device = None
     match_method = "name"
     try:
         device = Device.objects.get(site=site, name=device_name)
     except Device.DoesNotExist:
-        if serial:
-            device = Device.objects.filter(serial=serial).first()
-            if device:
-                match_method = "serial"
-        if device is None and asset_tag:
-            device = Device.objects.filter(asset_tag=asset_tag).first()
-            if device:
-                match_method = "asset tag"
+        # Fall back to source-ID link, serial, and asset_tag (mirrors preview matching)
+        device, match_method = _find_existing_device(profile, source_id, site, device_name, serial, asset_tag, Device)
 
     if device is not None:
         if profile.update_existing:

--- a/netbox_data_import/engine.py
+++ b/netbox_data_import/engine.py
@@ -121,6 +121,37 @@ class ImportResult:
 # ---------------------------------------------------------------------------
 
 
+def _build_header_index_map(ws) -> dict[str, int]:
+    """Build a header-name → column-index map from the first worksheet row.
+
+    First occurrence wins when duplicate headers exist.
+    """
+    raw_headers: dict[str, int] = {}
+    for idx, cell in enumerate(ws[1]):
+        if cell.value is not None:
+            header = str(cell.value).strip()
+            if header not in raw_headers:
+                raw_headers[header] = idx
+    return raw_headers
+
+
+def _apply_transform_rules(row_dict: dict, raw_row, raw_headers: dict, transform_rules) -> None:
+    """Apply column transform rules in-place to *row_dict*."""
+    for rule in transform_rules:
+        idx = raw_headers.get(rule.source_column)
+        if idx is None:
+            continue
+        raw_value = raw_row[idx] if idx < len(raw_row) else None
+        if raw_value is None:
+            continue
+        raw_str = str(raw_value).strip()
+        m = re.fullmatch(rule.pattern, raw_str)
+        if m and rule.group_1_target and len(m.groups()) >= 1:
+            row_dict[rule.group_1_target] = m.group(1)
+        if m and rule.group_2_target and len(m.groups()) >= 2:
+            row_dict[rule.group_2_target] = m.group(2)
+
+
 def parse_file(file_obj, profile: ImportProfile) -> list[dict]:
     """Read the Excel file and return a list of row-dicts keyed by target_field name.
 
@@ -137,19 +168,12 @@ def parse_file(file_obj, profile: ImportProfile) -> list[dict]:
         raise ParseError(f"Sheet '{profile.sheet_name}' not found. Available sheets: {available}")
 
     ws = wb[profile.sheet_name]
-
-    # Build header→column-index map (first occurrence wins for duplicates)
-    raw_headers: dict[str, int] = {}
-    for idx, cell in enumerate(ws[1]):
-        if cell.value is not None:
-            header = str(cell.value).strip()
-            if header not in raw_headers:
-                raw_headers[header] = idx
+    raw_headers = _build_header_index_map(ws)
 
     # Build source_column→target_field map from profile
     col_map: dict[str, str] = {cm.source_column: cm.target_field for cm in profile.column_mappings.all()}
 
-    # Pre-fetch transform rules and resolutions for efficiency
+    # Pre-fetch transform rules for efficiency
     transform_rules = list(profile.column_transform_rules.all())
 
     rows = []
@@ -168,20 +192,7 @@ def parse_file(file_obj, profile: ImportProfile) -> list[dict]:
                 value = value.strip()
             row_dict[target_field] = value
 
-        # Apply column transform rules
-        for rule in transform_rules:
-            idx = raw_headers.get(rule.source_column)
-            if idx is None:
-                continue
-            raw_value = row[idx] if idx < len(row) else None
-            if raw_value is None:
-                continue
-            raw_str = str(raw_value).strip()
-            m = re.fullmatch(rule.pattern, raw_str)
-            if m and rule.group_1_target and len(m.groups()) >= 1:
-                row_dict[rule.group_1_target] = m.group(1)
-            if m and rule.group_2_target and len(m.groups()) >= 2:
-                row_dict[rule.group_2_target] = m.group(2)
+        _apply_transform_rules(row_dict, row, raw_headers, transform_rules)
 
         # Apply saved resolutions (rerere)
         source_id = row_dict.get("source_id", "")
@@ -236,60 +247,137 @@ def _resolve_device_type_slugs(make: str, model: str, profile: ImportProfile) ->
 
 
 # ---------------------------------------------------------------------------
-# Main import runner
+# Main import runner — pass helpers
 # ---------------------------------------------------------------------------
 
+# Value-translation maps (shared across passes)
+_SIDE_MAP = {
+    "front": None,  # filled lazily once DeviceFaceChoices is imported
+    "back": None,
+    "rear": None,
+}
+_AIRFLOW_MAP = {}
+_STATUS_MAP = {
+    "live": "active",
+    "production": "active",
+    "planned": "planned",
+    "staged": "staged",
+    "failed": "failed",
+    "offline": "offline",
+    "decommissioning": "decommissioning",
+}
 
-def run_import(rows: list[dict], profile: ImportProfile, context: dict, dry_run: bool = True) -> ImportResult:
-    """Run (or preview) the import.
 
-    context keys: site, location (optional), tenant (optional)
-    dry_run=True  → no DB writes, returns what *would* happen
-    dry_run=False → writes to DB
-    """
-    # Lazy imports to avoid circular imports at module load time
-    from dcim.models import (
-        Device,
-        DeviceRole,
-        DeviceType,
-        Manufacturer,
-        Rack,
-    )
-    from dcim.choices import DeviceFaceChoices, DeviceAirflowChoices
+def _get_translation_maps():
+    """Return (SIDE_MAP, AIRFLOW_MAP, STATUS_MAP) with lazy-imported choice values."""
+    from dcim.choices import DeviceAirflowChoices, DeviceFaceChoices
 
-    site = context["site"]
-    location = context.get("location")
-    tenant = context.get("tenant")
-
-    # Build class→role lookup from profile
-    class_role_map: dict[str, object] = {crm.source_class: crm for crm in profile.class_role_mappings.all()}
-
-    # Value-translation maps (same as original script)
-    SIDE_MAP = {
+    side = {
         "front": DeviceFaceChoices.FACE_FRONT,
         "back": DeviceFaceChoices.FACE_REAR,
         "rear": DeviceFaceChoices.FACE_REAR,
     }
-    AIRFLOW_MAP = {
+    airflow = {
         "front to back": DeviceAirflowChoices.AIRFLOW_FRONT_TO_REAR,
         "back to front": DeviceAirflowChoices.AIRFLOW_REAR_TO_FRONT,
         "passive": DeviceAirflowChoices.AIRFLOW_PASSIVE,
     }
-    STATUS_MAP = {
-        "live": "active",
-        "production": "active",
-        "planned": "planned",
-        "staged": "staged",
-        "failed": "failed",
-        "offline": "offline",
-        "decommissioning": "decommissioning",
-    }
+    return side, airflow, _STATUS_MAP
 
-    result = ImportResult()
 
-    # ------------------------------------------------------------------
-    # Pass 1 – ensure Manufacturer + DeviceType + DeviceRole exist
-    # ------------------------------------------------------------------
+def _ensure_manufacturer(mfg_slug, make, seen_manufacturers, profile, result, dry_run, row, Manufacturer):
+    """Create (or preview-create) a manufacturer if not yet seen."""
+    if mfg_slug in seen_manufacturers:
+        return
+    seen_manufacturers.add(mfg_slug)
+    if not dry_run:
+        Manufacturer.objects.get_or_create(slug=mfg_slug, defaults={"name": make})
+    elif not Manufacturer.objects.filter(slug=mfg_slug).exists() and profile.create_missing_device_types:
+        result.rows.append(
+            RowResult(
+                row_number=row["_row_number"],
+                source_id=str(row.get("source_id", "")),
+                name=make,
+                action="create",
+                object_type="manufacturer",
+                detail=f"Would create manufacturer '{make}' (slug: {mfg_slug})",
+                extra_data={"source_make": make, "mfg_slug": mfg_slug},
+            )
+        )
+
+
+def _ensure_device_type(
+    mfg_slug, dt_slug, make, model, u_height, seen_device_types, profile, result, dry_run, row, Manufacturer, DeviceType
+):  # noqa: E501
+    """Create (or preview-create) a device type if not yet seen."""
+    dt_key = (mfg_slug, dt_slug)
+    if dt_key in seen_device_types:
+        return
+    seen_device_types.add(dt_key)
+    if not dry_run:
+        if profile.create_missing_device_types:
+            mfg, _ = Manufacturer.objects.get_or_create(slug=mfg_slug, defaults={"name": make})
+            DeviceType.objects.get_or_create(
+                manufacturer=mfg, slug=dt_slug, defaults={"model": model, "u_height": u_height}
+            )
+        return
+    exists = DeviceType.objects.filter(manufacturer__slug=mfg_slug, slug=dt_slug).exists()
+    if exists:
+        return
+    if profile.create_missing_device_types:
+        result.rows.append(
+            RowResult(
+                row_number=row["_row_number"],
+                source_id=str(row.get("source_id", "")),
+                name=f"{make} / {model}",
+                action="create",
+                object_type="device_type",
+                detail=f"Would create device type '{model}' under '{make}'",
+                extra_data={
+                    "source_make": make,
+                    "source_model": model,
+                    "mfg_slug": mfg_slug,
+                    "dt_slug": dt_slug,
+                    "u_height": u_height,
+                },
+            )
+        )
+    else:
+        result.rows.append(
+            RowResult(
+                row_number=row["_row_number"],
+                source_id=str(row.get("source_id", "")),
+                name=f"{make} / {model}",
+                action="error",
+                object_type="device_type",
+                detail=f"Device type not found: {make} / {model} — add a mapping or enable 'Create missing device types'",
+                extra_data={
+                    "source_make": make,
+                    "source_model": model,
+                    "mfg_slug": mfg_slug,
+                    "dt_slug": dt_slug,
+                    "u_height": u_height,
+                },
+            )
+        )
+
+
+def _ensure_device_role(crm, seen_roles, dry_run, DeviceRole):
+    """Create a device role if not yet seen."""
+    if not (crm and crm.role_slug and crm.role_slug not in seen_roles):
+        return
+    seen_roles.add(crm.role_slug)
+    if not dry_run:
+        DeviceRole.objects.get_or_create(
+            slug=crm.role_slug,
+            defaults={"name": crm.role_slug.replace("-", " ").title(), "color": "9e9e9e"},
+        )
+
+
+def _pass1_ensure_types(rows, profile, class_role_map, result, dry_run):
+    """Pass 1: ensure Manufacturer, DeviceType, and DeviceRole objects exist."""
+    from dcim.models import DeviceRole, DeviceType, Manufacturer
+
     seen_manufacturers: set[str] = set()
     seen_device_types: set[tuple] = set()
     seen_roles: set[str] = set()
@@ -298,101 +386,109 @@ def run_import(rows: list[dict], profile: ImportProfile, context: dict, dry_run:
         device_class = str(row.get("device_class", "")).strip()
         crm = class_role_map.get(device_class)
         if crm and (crm.creates_rack or crm.ignore):
-            continue  # racks and ignored classes don't need device type
+            continue
 
         make = " ".join(str(row.get("make", "Unknown")).split()) or "Unknown"
         model = " ".join(str(row.get("model", "Unknown")).split()) or "Unknown"
         u_height_raw = row.get("u_height", 1)
-
         try:
             u_height = max(1, int(float(u_height_raw)))
         except (TypeError, ValueError):
             u_height = 1
 
         mfg_slug, dt_slug, _ = _resolve_device_type_slugs(make, model, profile)
+        _ensure_manufacturer(mfg_slug, make, seen_manufacturers, profile, result, dry_run, row, Manufacturer)
+        _ensure_device_type(
+            mfg_slug,
+            dt_slug,
+            make,
+            model,
+            u_height,
+            seen_device_types,
+            profile,
+            result,
+            dry_run,
+            row,
+            Manufacturer,
+            DeviceType,
+        )  # noqa: E501
+        _ensure_device_role(crm, seen_roles, dry_run, DeviceRole)
 
-        if mfg_slug not in seen_manufacturers:
-            seen_manufacturers.add(mfg_slug)
-            if not dry_run:
-                Manufacturer.objects.get_or_create(slug=mfg_slug, defaults={"name": make})
-            else:
-                exists = Manufacturer.objects.filter(slug=mfg_slug).exists()
-                if not exists and profile.create_missing_device_types:
-                    result.rows.append(
-                        RowResult(
-                            row_number=row["_row_number"],
-                            source_id=str(row.get("source_id", "")),
-                            name=make,
-                            action="create",
-                            object_type="manufacturer",
-                            detail=f"Would create manufacturer '{make}' (slug: {mfg_slug})",
-                            extra_data={"source_make": make, "mfg_slug": mfg_slug},
-                        )
-                    )
 
-        dt_key = (mfg_slug, dt_slug)
-        if dt_key not in seen_device_types:
-            seen_device_types.add(dt_key)
-            if not dry_run:
-                if profile.create_missing_device_types:
-                    mfg, _ = Manufacturer.objects.get_or_create(slug=mfg_slug, defaults={"name": make})
-                    DeviceType.objects.get_or_create(
-                        manufacturer=mfg,
-                        slug=dt_slug,
-                        defaults={"model": model, "u_height": u_height},
-                    )
-            else:
-                exists = DeviceType.objects.filter(manufacturer__slug=mfg_slug, slug=dt_slug).exists()
-                if not exists:
-                    if profile.create_missing_device_types:
-                        result.rows.append(
-                            RowResult(
-                                row_number=row["_row_number"],
-                                source_id=str(row.get("source_id", "")),
-                                name=f"{make} / {model}",
-                                action="create",
-                                object_type="device_type",
-                                detail=f"Would create device type '{model}' under '{make}'",
-                                extra_data={
-                                    "source_make": make,
-                                    "source_model": model,
-                                    "mfg_slug": mfg_slug,
-                                    "dt_slug": dt_slug,
-                                    "u_height": u_height,
-                                },
-                            )
-                        )
-                    else:
-                        result.rows.append(
-                            RowResult(
-                                row_number=row["_row_number"],
-                                source_id=str(row.get("source_id", "")),
-                                name=f"{make} / {model}",
-                                action="error",
-                                object_type="device_type",
-                                detail=f"Device type not found: {make} / {model} — add a mapping or enable 'Create missing device types'",
-                                extra_data={
-                                    "source_make": make,
-                                    "source_model": model,
-                                    "mfg_slug": mfg_slug,
-                                    "dt_slug": dt_slug,
-                                    "u_height": u_height,
-                                },
-                            )
-                        )
-
-        if crm and crm.role_slug and crm.role_slug not in seen_roles:
-            seen_roles.add(crm.role_slug)
-            if not dry_run:
-                DeviceRole.objects.get_or_create(
-                    slug=crm.role_slug,
-                    defaults={"name": crm.role_slug.replace("-", " ").title(), "color": "9e9e9e"},
+def _write_rack_to_db(
+    rack_name,
+    site,
+    location,
+    tenant,
+    u_height,
+    serial,
+    profile,
+    source_id,
+    row,
+    rack_map,
+    result,
+    update_existing,
+    Rack,
+):  # noqa: E501
+    """Write or update a rack in the database and record the result."""
+    try:
+        rack = Rack.objects.get(site=site, name=rack_name)
+        if update_existing:
+            rack.u_height = u_height
+            rack.serial = serial or rack.serial
+            if location:
+                rack.location = location
+            if tenant:
+                rack.tenant = tenant
+            rack.save()
+            rack_map[rack_name] = rack
+            result.rows.append(
+                RowResult(
+                    row_number=row["_row_number"],
+                    source_id=source_id,
+                    name=rack_name,
+                    action="update",
+                    object_type="rack",
+                    detail=f"Updated rack '{rack_name}'",
+                    netbox_url=rack.get_absolute_url(),
                 )
+            )
+        else:
+            rack_map[rack_name] = rack
+            result.rows.append(
+                RowResult(
+                    row_number=row["_row_number"],
+                    source_id=source_id,
+                    name=rack_name,
+                    action="skip",
+                    object_type="rack",
+                    detail=f"Rack '{rack_name}' already exists (update_existing=False)",
+                )
+            )
+    except Rack.DoesNotExist:
+        rack = Rack.objects.create(
+            site=site, location=location, name=rack_name, tenant=tenant, u_height=u_height, serial=serial
+        )
+        _store_source_id(rack, profile, source_id)
+        rack_map[rack_name] = rack
+        result.rows.append(
+            RowResult(
+                row_number=row["_row_number"],
+                source_id=source_id,
+                name=rack_name,
+                action="create",
+                object_type="rack",
+                detail=f"Created rack '{rack_name}' ({u_height}U)",
+                netbox_url=rack.get_absolute_url(),
+            )
+        )
 
-    # ------------------------------------------------------------------
-    # Pass 2 – Racks
-    # ------------------------------------------------------------------
-    rack_map: dict[str, object] = {}  # source rack_name → Rack (or name in dry_run)
+
+def _pass2_process_racks(rows, profile, site, location, tenant, class_role_map, result, dry_run):
+    """Pass 2: create or update Rack objects. Returns rack_name→Rack map."""
+    from dcim.models import Rack
+
+    rack_map: dict[str, object] = {}
 
     for row in rows:
         device_class = str(row.get("device_class", "")).strip()
@@ -425,14 +521,13 @@ def run_import(rows: list[dict], profile: ImportProfile, context: dict, dry_run:
 
         if dry_run:
             try:
-                rack = Rack.objects.get(site=site, name=rack_name)
+                Rack.objects.get(site=site, name=rack_name)
                 action = "update" if profile.update_existing else "skip"
                 detail = f"Rack '{rack_name}' already exists"
-                rack_map[rack_name] = rack_name
             except Rack.DoesNotExist:
                 action = "create"
                 detail = f"Would create rack '{rack_name}' ({u_height}U) at site '{site}'"
-                rack_map[rack_name] = rack_name
+            rack_map[rack_name] = rack_name
             result.rows.append(
                 RowResult(
                     row_number=row["_row_number"],
@@ -444,71 +539,262 @@ def run_import(rows: list[dict], profile: ImportProfile, context: dict, dry_run:
                 )
             )
         else:
-            try:
-                rack = Rack.objects.get(site=site, name=rack_name)
-                if profile.update_existing:
-                    rack.u_height = u_height
-                    rack.serial = serial or rack.serial
-                    if location:
-                        rack.location = location
-                    if tenant:
-                        rack.tenant = tenant
-                    rack.save()
-                    rack_map[rack_name] = rack
-                    result.rows.append(
-                        RowResult(
-                            row_number=row["_row_number"],
-                            source_id=source_id,
-                            name=rack_name,
-                            action="update",
-                            object_type="rack",
-                            detail=f"Updated rack '{rack_name}'",
-                            netbox_url=rack.get_absolute_url(),
-                        )
-                    )
-                else:
-                    rack_map[rack_name] = rack
-                    result.rows.append(
-                        RowResult(
-                            row_number=row["_row_number"],
-                            source_id=source_id,
-                            name=rack_name,
-                            action="skip",
-                            object_type="rack",
-                            detail=f"Rack '{rack_name}' already exists (update_existing=False)",
-                        )
-                    )
-            except Rack.DoesNotExist:
-                rack = Rack.objects.create(
-                    site=site,
-                    location=location,
-                    name=rack_name,
-                    tenant=tenant,
-                    u_height=u_height,
-                    serial=serial,
-                )
-                _store_source_id(rack, profile, source_id)
-                rack_map[rack_name] = rack
-                result.rows.append(
-                    RowResult(
-                        row_number=row["_row_number"],
-                        source_id=source_id,
-                        name=rack_name,
-                        action="create",
-                        object_type="rack",
-                        detail=f"Created rack '{rack_name}' ({u_height}U)",
-                        netbox_url=rack.get_absolute_url(),
-                    )
-                )
+            _write_rack_to_db(
+                rack_name,
+                site,
+                location,
+                tenant,
+                u_height,
+                serial,
+                profile,
+                source_id,
+                row,
+                rack_map,
+                result,
+                profile.update_existing,
+                Rack,
+            )
 
-    # ------------------------------------------------------------------
-    # Pass 3 – Devices
-    # ------------------------------------------------------------------
+    return rack_map
+
+
+def _find_existing_device(profile, source_id, site, device_name, serial, asset_tag, Device):
+    """Look up a pre-existing NetBox device by source-ID link, serial, or asset_tag.
+
+    Returns (device, match_method) or (None, None).
+    """
+    existing_match = profile.device_matches.filter(source_id=source_id).first()
+    matched_device = None
+    match_method = None
+    if existing_match:
+        try:
+            matched_device = Device.objects.get(pk=existing_match.netbox_device_id)
+            match_method = "source ID link"
+        except Device.DoesNotExist:
+            pass
+
+    if matched_device is None and serial:
+        try:
+            matched_device = Device.objects.get(serial=serial)
+            match_method = "serial"
+        except (Device.DoesNotExist, Device.MultipleObjectsReturned):
+            pass
+
+    if matched_device is None and asset_tag:
+        try:
+            matched_device = Device.objects.get(asset_tag=asset_tag)
+            match_method = "asset tag"
+        except (Device.DoesNotExist, Device.MultipleObjectsReturned):
+            pass
+
+    return matched_device, match_method
+
+
+def _preview_device_row(
+    row,
+    profile,
+    site,
+    rack_map,
+    make,
+    model,
+    mfg_slug,
+    dt_slug,
+    source_id,
+    device_name,
+    serial,
+    asset_tag,
+    DeviceType,
+    Device,
+):  # noqa: E501
+    """Return a RowResult for *dry_run* mode (no DB writes)."""
+    dt_exists = DeviceType.objects.filter(manufacturer__slug=mfg_slug, slug=dt_slug).exists()
+    if not dt_exists and not profile.create_missing_device_types:
+        return RowResult(
+            row_number=row["_row_number"],
+            source_id=source_id,
+            name=device_name,
+            action="error",
+            object_type="device",
+            detail=f"Device type not found: {make} / {model} (slug: {mfg_slug}/{dt_slug})",
+        )
+
+    rack_name = str(row.get("rack_name", "")).strip()
+    rack_label = rack_name if rack_name in rack_map else f"{rack_name} (not found)"
+    position = row.get("u_position")
+
+    try:
+        Device.objects.get(site=site, name=device_name)
+        action = "update" if profile.update_existing else "skip"
+        detail = f"Device '{device_name}' already exists"
+    except Device.DoesNotExist:
+        matched_device, match_method = _find_existing_device(
+            profile, source_id, site, device_name, serial, asset_tag, Device
+        )
+        if matched_device is not None:
+            action = "update"
+            detail = f"Matched to existing device '{matched_device.name}' (by {match_method})"
+        else:
+            action = "create"
+            detail = f"Would create device '{device_name}' in {rack_label} U{position}"
+
+    return RowResult(
+        row_number=row["_row_number"],
+        source_id=source_id,
+        name=device_name,
+        action=action,
+        object_type="device",
+        detail=detail,
+        rack_name=rack_name,
+        extra_data={"source_make": make, "source_model": model, "asset_tag": asset_tag or ""},
+    )
+
+
+def _write_device_row(
+    row,
+    profile,
+    site,
+    location,
+    tenant,
+    rack_map,
+    make,
+    model,
+    crm,
+    mfg_slug,
+    dt_slug,
+    source_id,
+    device_name,
+    serial,
+    asset_tag,
+    position,
+    face,
+    airflow,
+    status,
+    DeviceType,
+    DeviceRole,
+    Rack,
+    Device,
+):  # noqa: E501
+    """Write or update a device in the DB and return a RowResult."""
+    rack_name = str(row.get("rack_name", "")).strip()
+    try:
+        device_type = DeviceType.objects.get(manufacturer__slug=mfg_slug, slug=dt_slug)
+    except DeviceType.DoesNotExist:
+        return RowResult(
+            row_number=row["_row_number"],
+            source_id=source_id,
+            name=device_name,
+            action="error",
+            object_type="device",
+            detail=f"Device type not found: {mfg_slug}/{dt_slug}",
+        )
+
+    try:
+        device_role = DeviceRole.objects.get(slug=crm.role_slug)
+    except DeviceRole.DoesNotExist:
+        return RowResult(
+            row_number=row["_row_number"],
+            source_id=source_id,
+            name=device_name,
+            action="error",
+            object_type="device",
+            detail=f"Device role not found: {crm.role_slug}",
+        )
+
+    rack = rack_map.get(rack_name) if rack_name else None
+
+    device = None
+    match_method = "name"
+    try:
+        device = Device.objects.get(site=site, name=device_name)
+    except Device.DoesNotExist:
+        if serial:
+            device = Device.objects.filter(serial=serial).first()
+            if device:
+                match_method = "serial"
+        if device is None and asset_tag:
+            device = Device.objects.filter(asset_tag=asset_tag).first()
+            if device:
+                match_method = "asset tag"
+
+    if device is not None:
+        if profile.update_existing:
+            device.device_type = device_type
+            device.role = device_role
+            device.rack = rack if isinstance(rack, Rack) else None
+            device.position = position
+            device.face = face
+            device.airflow = airflow
+            device.status = status
+            device.serial = serial or device.serial
+            if asset_tag:
+                device.asset_tag = asset_tag
+            if tenant:
+                device.tenant = tenant
+            device.save()
+            _store_source_id(device, profile, source_id)
+            return RowResult(
+                row_number=row["_row_number"],
+                source_id=source_id,
+                name=device_name,
+                action="update",
+                object_type="device",
+                detail=f"Updated device '{device.name}' (matched by {match_method})",
+                netbox_url=device.get_absolute_url(),
+                rack_name=rack_name,
+                extra_data={"source_make": make, "source_model": model, "asset_tag": asset_tag or ""},
+            )
+        return RowResult(
+            row_number=row["_row_number"],
+            source_id=source_id,
+            name=device_name,
+            action="skip",
+            object_type="device",
+            detail=f"Device '{device.name}' already exists (update_existing=False)",
+            rack_name=rack_name,
+            extra_data={"source_make": make, "source_model": model, "asset_tag": asset_tag or ""},
+        )
+
+    device = Device.objects.create(
+        site=site,
+        location=location,
+        name=device_name,
+        device_type=device_type,
+        role=device_role,
+        rack=rack if isinstance(rack, Rack) else None,
+        position=position,
+        face=face,
+        airflow=airflow,
+        status=status,
+        serial=serial,
+        asset_tag=asset_tag,
+        tenant=tenant,
+    )
+    _store_source_id(device, profile, source_id)
+    return RowResult(
+        row_number=row["_row_number"],
+        source_id=source_id,
+        name=device_name,
+        action="create",
+        object_type="device",
+        detail=f"Created device '{device_name}' in {rack_name} U{position}",
+        netbox_url=device.get_absolute_url(),
+        rack_name=rack_name,
+        extra_data={"source_make": make, "source_model": model, "asset_tag": asset_tag or ""},
+    )
+
+
+def _pass3_process_devices(rows, profile, site, location, tenant, class_role_map, rack_map, result, dry_run):
+    """Pass 3: create or update Device objects."""
+    from dcim.models import Device, DeviceRole, DeviceType, Rack
+    from .models import IgnoredDevice
+
+    side_map, airflow_map, status_map = _get_translation_maps()
+
     for row in rows:
         device_class = str(row.get("device_class", "")).strip()
         crm = class_role_map.get(device_class)
         if crm and crm.creates_rack:
-            continue  # already handled as rack
+            continue
 
         source_id = str(row.get("source_id", ""))
         device_name = str(row.get("device_name", "")).strip()
@@ -538,15 +824,6 @@ def run_import(rows: list[dict], profile: ImportProfile, context: dict, dry_run:
         except (TypeError, ValueError):
             position = None
 
-        status_raw = str(row.get("status", "")).strip().lower()
-        device_status = STATUS_MAP.get(status_raw, "active")
-
-        face_raw = str(row.get("face", "")).strip().lower()
-        device_face = SIDE_MAP.get(face_raw)
-
-        airflow_raw = str(row.get("airflow", "")).strip().lower()
-        device_airflow = AIRFLOW_MAP.get(airflow_raw)
-
         if not device_name:
             result.rows.append(
                 RowResult(
@@ -559,9 +836,6 @@ def run_import(rows: list[dict], profile: ImportProfile, context: dict, dry_run:
                 )
             )
             continue
-
-        # Check per-device ignore list
-        from .models import IgnoredDevice
 
         if IgnoredDevice.objects.filter(profile=profile, source_id=source_id).exists():
             result.rows.append(
@@ -597,7 +871,6 @@ def run_import(rows: list[dict], profile: ImportProfile, context: dict, dry_run:
             )
             continue
 
-        # Check class-level ignore
         if crm.ignore:
             result.rows.append(
                 RowResult(
@@ -613,197 +886,78 @@ def run_import(rows: list[dict], profile: ImportProfile, context: dict, dry_run:
             continue
 
         mfg_slug, dt_slug, _ = _resolve_device_type_slugs(make, model, profile)
+        device_status = status_map.get(str(row.get("status", "")).strip().lower(), "active")
+        device_face = side_map.get(str(row.get("face", "")).strip().lower())
+        device_airflow = airflow_map.get(str(row.get("airflow", "")).strip().lower())
 
         if dry_run:
-            # Check if device type exists
-            dt_exists = DeviceType.objects.filter(manufacturer__slug=mfg_slug, slug=dt_slug).exists()
-            if not dt_exists and not profile.create_missing_device_types:
-                result.rows.append(
-                    RowResult(
-                        row_number=row["_row_number"],
-                        source_id=source_id,
-                        name=device_name,
-                        action="error",
-                        object_type="device",
-                        detail=f"Device type not found: {make} / {model} (slug: {mfg_slug}/{dt_slug})",
-                    )
-                )
-                continue
-
-            rack_label = rack_name if rack_name in rack_map else f"{rack_name} (not found)"
-            try:
-                Device.objects.get(site=site, name=device_name)
-                action = "update" if profile.update_existing else "skip"
-                detail = f"Device '{device_name}' already exists"
-            except Device.DoesNotExist:
-                # 1. Check manual source-ID link
-                existing_match = profile.device_matches.filter(source_id=source_id).first()
-                matched_device = None
-                match_method = None
-                if existing_match:
-                    try:
-                        matched_device = Device.objects.get(pk=existing_match.netbox_device_id)
-                        match_method = "source ID link"
-                    except Device.DoesNotExist:
-                        pass  # stale — will fall through to serial/asset_tag/create
-
-                # 2. Try serial match
-                if matched_device is None and serial:
-                    try:
-                        matched_device = Device.objects.get(serial=serial)
-                        match_method = "serial"
-                    except (Device.DoesNotExist, Device.MultipleObjectsReturned):
-                        pass
-
-                # 3. Try asset_tag match
-                if matched_device is None and asset_tag:
-                    try:
-                        matched_device = Device.objects.get(asset_tag=asset_tag)
-                        match_method = "asset tag"
-                    except (Device.DoesNotExist, Device.MultipleObjectsReturned):
-                        pass
-
-                if matched_device is not None:
-                    action = "update"
-                    detail = f"Matched to existing device '{matched_device.name}' (by {match_method})"
-                else:
-                    action = "create"
-                    detail = f"Would create device '{device_name}' in {rack_label} U{position}"
-
-            result.rows.append(
-                RowResult(
-                    row_number=row["_row_number"],
-                    source_id=source_id,
-                    name=device_name,
-                    action=action,
-                    object_type="device",
-                    detail=detail,
-                    rack_name=rack_name,
-                    extra_data={"source_make": make, "source_model": model, "asset_tag": asset_tag or ""},
-                )
-            )
+            row_result = _preview_device_row(
+                row,
+                profile,
+                site,
+                rack_map,
+                make,
+                model,
+                mfg_slug,
+                dt_slug,
+                source_id,
+                device_name,
+                serial,
+                asset_tag,
+                DeviceType,
+                Device,
+            )  # noqa: E501
         else:
-            # Resolve device type
-            try:
-                device_type = DeviceType.objects.get(manufacturer__slug=mfg_slug, slug=dt_slug)
-            except DeviceType.DoesNotExist:
-                result.rows.append(
-                    RowResult(
-                        row_number=row["_row_number"],
-                        source_id=source_id,
-                        name=device_name,
-                        action="error",
-                        object_type="device",
-                        detail=f"Device type not found: {mfg_slug}/{dt_slug}",
-                    )
-                )
-                continue
+            row_result = _write_device_row(
+                row,
+                profile,
+                site,
+                location,
+                tenant,
+                rack_map,
+                make,
+                model,
+                crm,
+                mfg_slug,
+                dt_slug,
+                source_id,
+                device_name,
+                serial,
+                asset_tag,
+                position,
+                device_face,
+                device_airflow,
+                device_status,
+                DeviceType,
+                DeviceRole,
+                Rack,
+                Device,
+            )  # noqa: E501
+        result.rows.append(row_result)
 
-            # Resolve role
-            try:
-                device_role = DeviceRole.objects.get(slug=crm.role_slug)
-            except DeviceRole.DoesNotExist:
-                result.rows.append(
-                    RowResult(
-                        row_number=row["_row_number"],
-                        source_id=source_id,
-                        name=device_name,
-                        action="error",
-                        object_type="device",
-                        detail=f"Device role not found: {crm.role_slug}",
-                    )
-                )
-                continue
 
-            rack = rack_map.get(rack_name) if rack_name else None
+# ---------------------------------------------------------------------------
+# Main import runner
+# ---------------------------------------------------------------------------
 
-            # Try to find an existing device by name, then serial, then asset_tag
-            device = None
-            match_method = "name"
-            try:
-                device = Device.objects.get(site=site, name=device_name)
-            except Device.DoesNotExist:
-                if serial:
-                    device = Device.objects.filter(serial=serial).first()
-                    if device:
-                        match_method = "serial"
-                if device is None and asset_tag:
-                    device = Device.objects.filter(asset_tag=asset_tag).first()
-                    if device:
-                        match_method = "asset tag"
 
-            if device is not None:
-                if profile.update_existing:
-                    device.device_type = device_type
-                    device.role = device_role
-                    device.rack = rack if isinstance(rack, Rack) else None
-                    device.position = position
-                    device.face = device_face
-                    device.airflow = device_airflow
-                    device.status = device_status
-                    device.serial = serial or device.serial
-                    if asset_tag:
-                        device.asset_tag = asset_tag
-                    if tenant:
-                        device.tenant = tenant
-                    device.save()
-                    _store_source_id(device, profile, source_id)
-                    result.rows.append(
-                        RowResult(
-                            row_number=row["_row_number"],
-                            source_id=source_id,
-                            name=device_name,
-                            action="update",
-                            object_type="device",
-                            detail=f"Updated device '{device.name}' (matched by {match_method})",
-                            netbox_url=device.get_absolute_url(),
-                            rack_name=rack_name,
-                            extra_data={"source_make": make, "source_model": model, "asset_tag": asset_tag or ""},
-                        )
-                    )
-                else:
-                    result.rows.append(
-                        RowResult(
-                            row_number=row["_row_number"],
-                            source_id=source_id,
-                            name=device_name,
-                            action="skip",
-                            object_type="device",
-                            detail=f"Device '{device.name}' already exists (update_existing=False)",
-                            rack_name=rack_name,
-                            extra_data={"source_make": make, "source_model": model, "asset_tag": asset_tag or ""},
-                        )
-                    )
-            else:
-                device = Device.objects.create(
-                    site=site,
-                    location=location,
-                    name=device_name,
-                    device_type=device_type,
-                    role=device_role,
-                    rack=rack if isinstance(rack, Rack) else None,
-                    position=position,
-                    face=device_face,
-                    airflow=device_airflow,
-                    status=device_status,
-                    serial=serial,
-                    asset_tag=asset_tag,
-                    tenant=tenant,
-                )
-                _store_source_id(device, profile, source_id)
-                result.rows.append(
-                    RowResult(
-                        row_number=row["_row_number"],
-                        source_id=source_id,
-                        name=device_name,
-                        action="create",
-                        object_type="device",
-                        detail=f"Created device '{device_name}' in {rack_name} U{position}",
-                        netbox_url=device.get_absolute_url(),
-                        rack_name=rack_name,
-                        extra_data={"source_make": make, "source_model": model, "asset_tag": asset_tag or ""},
-                    )
-                )
+def run_import(rows: list[dict], profile: ImportProfile, context: dict, dry_run: bool = True) -> ImportResult:
+    """Run (or preview) the import.
+
+    context keys: site, location (optional), tenant (optional)
+    dry_run=True  → no DB writes, returns what *would* happen
+    dry_run=False → writes to DB
+    """
+    site = context["site"]
+    location = context.get("location")
+    tenant = context.get("tenant")
+
+    class_role_map: dict[str, object] = {crm.source_class: crm for crm in profile.class_role_mappings.all()}
+    result = ImportResult()
+
+    _pass1_ensure_types(rows, profile, class_role_map, result, dry_run)
+    rack_map = _pass2_process_racks(rows, profile, site, location, tenant, class_role_map, result, dry_run)
+    _pass3_process_devices(rows, profile, site, location, tenant, class_role_map, rack_map, result, dry_run)
 
     result._recompute_counts()
     return result

--- a/netbox_data_import/engine.py
+++ b/netbox_data_import/engine.py
@@ -627,7 +627,10 @@ def _preview_device_row(
         )
 
     rack_name = str(row.get("rack_name", "")).strip()
-    rack_label = rack_name if rack_name in rack_map else f"{rack_name} (not found)"
+    if rack_name:
+        rack_label = rack_name if rack_name in rack_map else f"{rack_name} (not found)"
+    else:
+        rack_label = "(no rack)"
     position = row.get("u_position")
 
     try:

--- a/netbox_data_import/engine.py
+++ b/netbox_data_import/engine.py
@@ -652,21 +652,21 @@ def _preview_device_row(
     except (TypeError, ValueError):
         position = None
 
-    try:
-        Device.objects.get(site=site, name=device_name)
+    # _find_existing_device checks DeviceExistingMatch → serial → asset_tag → name in that order,
+    # ensuring explicit operator mappings always take precedence over coincidental name matches.
+    matched_device, match_method = _find_existing_device(
+        profile, source_id, site, device_name, serial, asset_tag, Device
+    )
+    if matched_device is not None:
         action = "update" if profile.update_existing else "skip"
-        detail = f"Device '{device_name}' already exists"
-    except Device.DoesNotExist:
-        matched_device, match_method = _find_existing_device(
-            profile, source_id, site, device_name, serial, asset_tag, Device
-        )
-        if matched_device is not None:
-            action = "update" if profile.update_existing else "skip"
-            detail = f"Matched to existing device '{matched_device.name}' (by {match_method})"
+        if match_method == "name":
+            detail = f"Device '{device_name}' already exists"
         else:
-            action = "create"
-            _pos_label = f" U{position}" if position is not None else ""
-            detail = f"Would create device '{device_name}' in {rack_label}{_pos_label}"
+            detail = f"Matched to existing device '{matched_device.name}' (by {match_method})"
+    else:
+        action = "create"
+        _pos_label = f" U{position}" if position is not None else ""
+        detail = f"Would create device '{device_name}' in {rack_label}{_pos_label}"
 
     return RowResult(
         row_number=row["_row_number"],
@@ -735,13 +735,9 @@ def _write_device_row(
     if rack_name and rack is None:
         rack = Rack.objects.filter(site=site, name=rack_name).first()
 
-    device = None
-    match_method = "name"
-    try:
-        device = Device.objects.get(site=site, name=device_name)
-    except Device.DoesNotExist:
-        # Fall back to source-ID link, serial, and asset_tag (mirrors preview matching)
-        device, match_method = _find_existing_device(profile, source_id, site, device_name, serial, asset_tag, Device)
+    # _find_existing_device checks DeviceExistingMatch → serial → asset_tag → name in that order,
+    # ensuring explicit operator mappings always take precedence over coincidental name matches.
+    device, match_method = _find_existing_device(profile, source_id, site, device_name, serial, asset_tag, Device)
 
     if device is not None:
         if profile.update_existing:

--- a/netbox_data_import/models.py
+++ b/netbox_data_import/models.py
@@ -178,8 +178,8 @@ class ImportJob(models.Model):
         return f"Import {self.pk} — {self.created:%Y-%m-%d %H:%M} ({self.input_filename})"
 
     def get_absolute_url(self):
-        """Return the detail URL for this import job."""
-        return reverse("plugins:netbox_data_import:importjob", args=[self.pk])
+        """Return the associated profile's URL (no per-job detail view exists)."""
+        return reverse("plugins:netbox_data_import:importprofile", args=[self.profile_id])
 
 
 class DeviceTypeMapping(models.Model):

--- a/netbox_data_import/models.py
+++ b/netbox_data_import/models.py
@@ -179,6 +179,8 @@ class ImportJob(models.Model):
 
     def get_absolute_url(self):
         """Return the associated profile's URL (no per-job detail view exists)."""
+        if not self.profile_id:
+            return reverse("plugins:netbox_data_import:importprofile_list")
         return reverse("plugins:netbox_data_import:importprofile", args=[self.profile_id])
 
 

--- a/netbox_data_import/tests/test_api.py
+++ b/netbox_data_import/tests/test_api.py
@@ -182,3 +182,181 @@ class ManufacturerMappingAPITest(BaseAPITestCase):
         """ManufacturerMapping is saved and retrievable."""
         mm = ManufacturerMapping.objects.get(profile=self.profile, source_make="Dell EMC")
         self.assertEqual(mm.netbox_manufacturer_slug, "dell")
+
+
+# ---------------------------------------------------------------------------
+# New API tests: profile_id filter for IgnoredDevice, ColumnTransformRule,
+# SourceResolution, and ImportJob viewsets.
+# ---------------------------------------------------------------------------
+
+
+class IgnoredDeviceAPITest(BaseAPITestCase):
+    """Tests for IgnoredDeviceViewSet ?profile_id filtering (lines 101-105 in api/views.py)."""
+
+    def setUp(self):
+        """Create two profiles each with one IgnoredDevice."""
+        super().setUp()
+        from netbox_data_import.models import IgnoredDevice
+
+        self.p1 = _make_profile("APIIgnoredP1")
+        self.p2 = _make_profile("APIIgnoredP2")
+        IgnoredDevice.objects.create(profile=self.p1, source_id="IGN-001", device_name="dev-p1")
+        IgnoredDevice.objects.create(profile=self.p2, source_id="IGN-001", device_name="dev-p2")
+
+    def test_list_all_ignored_devices(self):
+        """GET /api/plugins/data-import/ignored-devices/ returns 200 and at least 2 entries."""
+        import json
+
+        resp = self.client.get("/api/plugins/data-import/ignored-devices/", HTTP_ACCEPT="application/json")
+        self.assertEqual(resp.status_code, 200)
+        data = json.loads(resp.content)
+        self.assertGreaterEqual(data["count"], 2)
+
+    def test_filter_by_profile_id_returns_only_that_profile(self):
+        """GET ?profile_id=<p1.pk> returns only p1's IgnoredDevices."""
+        import json
+
+        resp = self.client.get(
+            f"/api/plugins/data-import/ignored-devices/?profile_id={self.p1.pk}",
+            HTTP_ACCEPT="application/json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = json.loads(resp.content)
+        self.assertEqual(data["count"], 1)
+        self.assertEqual(data["results"][0]["profile"], self.p1.pk)
+        self.assertEqual(data["results"][0]["device_name"], "dev-p1")
+
+
+class ColumnTransformRuleAPITest(BaseAPITestCase):
+    """Tests for ColumnTransformRuleViewSet ?profile_id filtering (lines 116-120 in api/views.py)."""
+
+    def setUp(self):
+        """Create two profiles each with one ColumnTransformRule."""
+        super().setUp()
+        from netbox_data_import.models import ColumnTransformRule
+
+        self.p1 = _make_profile("APICTRProfile1")
+        self.p2 = _make_profile("APICTRProfile2")
+        ColumnTransformRule.objects.create(
+            profile=self.p1,
+            source_column="Name",
+            pattern=r"^(\w+)$",
+            group_1_target="asset_tag",
+            group_2_target="",
+        )
+        ColumnTransformRule.objects.create(
+            profile=self.p2,
+            source_column="Name",
+            pattern=r"^(\w+)$",
+            group_1_target="asset_tag",
+            group_2_target="",
+        )
+
+    def test_list_all_column_transform_rules(self):
+        """GET /api/plugins/data-import/column-transforms/ returns 200."""
+        resp = self.client.get("/api/plugins/data-import/column-transforms/", HTTP_ACCEPT="application/json")
+        self.assertEqual(resp.status_code, 200)
+
+    def test_filter_by_profile_id(self):
+        """GET ?profile_id=<p1.pk> returns only p1's ColumnTransformRules."""
+        import json
+
+        resp = self.client.get(
+            f"/api/plugins/data-import/column-transforms/?profile_id={self.p1.pk}",
+            HTTP_ACCEPT="application/json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = json.loads(resp.content)
+        self.assertEqual(data["count"], 1)
+        for item in data["results"]:
+            self.assertEqual(item["profile"], self.p1.pk)
+
+
+class SourceResolutionAPITest(BaseAPITestCase):
+    """Tests for SourceResolutionViewSet ?profile_id filtering (lines 131-135 in api/views.py)."""
+
+    def setUp(self):
+        """Create two profiles each with one SourceResolution."""
+        super().setUp()
+        from netbox_data_import.models import SourceResolution
+
+        self.p1 = _make_profile("APISRProfile1")
+        self.p2 = _make_profile("APISRProfile2")
+        SourceResolution.objects.create(
+            profile=self.p1,
+            source_id="SR-001",
+            source_column="Name",
+            original_value="old-p1",
+            resolved_fields={"device_name": "new-p1"},
+        )
+        SourceResolution.objects.create(
+            profile=self.p2,
+            source_id="SR-001",
+            source_column="Name",
+            original_value="old-p2",
+            resolved_fields={"device_name": "new-p2"},
+        )
+
+    def test_list_all_source_resolutions(self):
+        """GET /api/plugins/data-import/source-resolutions/ returns 200."""
+        resp = self.client.get("/api/plugins/data-import/source-resolutions/", HTTP_ACCEPT="application/json")
+        self.assertEqual(resp.status_code, 200)
+
+    def test_filter_by_profile_id(self):
+        """GET ?profile_id=<p1.pk> returns only p1's SourceResolutions."""
+        import json
+
+        resp = self.client.get(
+            f"/api/plugins/data-import/source-resolutions/?profile_id={self.p1.pk}",
+            HTTP_ACCEPT="application/json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = json.loads(resp.content)
+        self.assertEqual(data["count"], 1)
+        self.assertEqual(data["results"][0]["profile"], self.p1.pk)
+
+
+class ImportJobAPITest(BaseAPITestCase):
+    """Tests for ImportJobViewSet ?profile_id filtering (lines 147-151 in api/views.py)."""
+
+    def setUp(self):
+        """Create two profiles each with one ImportJob."""
+        super().setUp()
+        from netbox_data_import.models import ImportJob
+
+        self.p1 = _make_profile("APIJobProfile1")
+        self.p2 = _make_profile("APIJobProfile2")
+        ImportJob.objects.create(
+            profile=self.p1,
+            input_filename="file-p1.xlsx",
+            dry_run=True,
+            site_name="site-p1",
+        )
+        ImportJob.objects.create(
+            profile=self.p2,
+            input_filename="file-p2.xlsx",
+            dry_run=False,
+            site_name="site-p2",
+        )
+
+    def test_list_all_import_jobs(self):
+        """GET /api/plugins/data-import/jobs/ returns 200 and at least 2 jobs."""
+        import json
+
+        resp = self.client.get("/api/plugins/data-import/jobs/", HTTP_ACCEPT="application/json")
+        self.assertEqual(resp.status_code, 200)
+        data = json.loads(resp.content)
+        self.assertGreaterEqual(data["count"], 2)
+
+    def test_filter_by_profile_id(self):
+        """GET ?profile_id=<p1.pk> returns only p1's ImportJobs."""
+        import json
+
+        resp = self.client.get(
+            f"/api/plugins/data-import/jobs/?profile_id={self.p1.pk}",
+            HTTP_ACCEPT="application/json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = json.loads(resp.content)
+        self.assertEqual(data["count"], 1)
+        self.assertEqual(data["results"][0]["input_filename"], "file-p1.xlsx")

--- a/netbox_data_import/tests/test_api.py
+++ b/netbox_data_import/tests/test_api.py
@@ -9,6 +9,7 @@ from netbox_data_import.models import (
     ClassRoleMapping,
     ColumnMapping,
     DeviceTypeMapping,
+    IgnoredDevice,
     ImportProfile,
     ManufacturerMapping,
 )
@@ -196,8 +197,6 @@ class IgnoredDeviceAPITest(BaseAPITestCase):
     def setUp(self):
         """Create two profiles each with one IgnoredDevice."""
         super().setUp()
-        from netbox_data_import.models import IgnoredDevice
-
         self.p1 = _make_profile("APIIgnoredP1")
         self.p2 = _make_profile("APIIgnoredP2")
         IgnoredDevice.objects.create(profile=self.p1, source_id="IGN-001", device_name="dev-p1")

--- a/netbox_data_import/tests/test_engine.py
+++ b/netbox_data_import/tests/test_engine.py
@@ -371,3 +371,67 @@ class EnsureDeviceTypeExecuteModeTest(TestCase):
         device_type_rows = [r for r in result.rows if r.object_type == "device_type"]
         self.assertEqual(len(device_type_rows), 1)
         self.assertEqual(device_type_rows[0].action, "error")
+
+
+class ParseFileEdgeCasesTest(TestCase):
+    """Tests for parse_file edge cases: empty rows and missing column headers."""
+
+    def test_empty_rows_are_skipped(self):
+        """parse_file skips fully-empty data rows (line 192 coverage)."""
+        import openpyxl
+        from io import BytesIO
+
+        profile = _make_profile("EmptyRowTest")
+
+        # Build an xlsx with one data row and one empty row
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.title = "Data"
+        ws.append(
+            [
+                "Id",
+                "Rack",
+                "Name",
+                "Class",
+                "Make",
+                "Model",
+                "UHeight",
+                "UPosition",
+                "Serial Number",
+                "Asset Tag",
+                "Status",
+            ]
+        )
+        ws.append(["SRC001", "Rack-01", "dev-01", "Server", "Dell", "R740", "1", "1", "", "", "active"])
+        ws.append([None, None, None, None, None, None, None, None, None, None, None])  # empty row
+        ws.append(["SRC002", "Rack-01", "dev-02", "Server", "Dell", "R740", "1", "2", "", "", "active"])
+
+        buf = BytesIO()
+        wb.save(buf)
+        buf.seek(0)
+        rows = parse_file(buf, profile)
+        # Only 2 non-empty rows
+        self.assertEqual(len(rows), 2)
+
+    def test_mapping_with_missing_source_column_skips(self):
+        """parse_file silently skips column mappings whose header doesn't exist in the file (line 198)."""
+        import openpyxl
+        from io import BytesIO
+
+        profile = _make_profile("MissingColTest")
+        # Add a mapping for a column that doesn't exist in the file
+        ColumnMapping.objects.create(profile=profile, source_column="NonExistentCol", target_field="tenant")
+
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.title = "Data"
+        ws.append(["Id", "Name", "Class"])
+        ws.append(["SRC001", "dev-01", "Server"])
+
+        buf = BytesIO()
+        wb.save(buf)
+        buf.seek(0)
+        rows = parse_file(buf, profile)
+        self.assertEqual(len(rows), 1)
+        # tenant should be absent (no mapping target applied since column didn't exist)
+        self.assertNotIn("tenant", rows[0])

--- a/netbox_data_import/tests/test_engine.py
+++ b/netbox_data_import/tests/test_engine.py
@@ -213,3 +213,161 @@ class RowResultSerializationTest(TestCase):
         self.assertEqual(len(restored.rows), 2)
         self.assertEqual(restored.counts.get("racks_created"), 1)
         self.assertEqual(restored.counts.get("devices_created"), 1)
+
+
+class PreviewDeviceRowTest(TestCase):
+    """Unit tests for _preview_device_row internals."""
+
+    def setUp(self):
+        from dcim.models import Site
+
+        self.site = Site.objects.create(name="Preview Site", slug="preview-site")
+        self.profile = _make_profile("Preview")
+
+    def test_rack_label_empty_rack_name(self):
+        """An empty rack_name produces '(no rack)' — no leading space in detail."""
+        from dcim.models import Device, DeviceType
+
+        from netbox_data_import.engine import _preview_device_row
+
+        row = {
+            "_row_number": 1,
+            "rack_name": "",
+            "u_position": 3,
+        }
+        result_row = _preview_device_row(
+            row=row,
+            profile=self.profile,
+            rack_map={},
+            site=self.site,
+            mfg_slug="test-mfg",
+            dt_slug="test-dt",
+            make="TestMake",
+            model="TestModel",
+            source_id="1",
+            device_name="test-device-01",
+            serial="",
+            asset_tag="",
+            DeviceType=DeviceType,
+            Device=Device,
+        )
+        # Should use '(no rack)' placeholder, not '  (not found)' with leading space
+        self.assertNotIn("  ", result_row.detail, "Detail should not contain double space")
+        self.assertIn("(no rack)", result_row.detail)
+
+    def test_rack_label_unknown_rack(self):
+        """A non-empty rack_name not in rack_map produces 'rack-X (not found)'."""
+        from dcim.models import Device, DeviceType
+
+        from netbox_data_import.engine import _preview_device_row
+
+        row = {
+            "_row_number": 2,
+            "rack_name": "RACK-99",
+            "u_position": 5,
+        }
+        result_row = _preview_device_row(
+            row=row,
+            profile=self.profile,
+            rack_map={},
+            site=self.site,
+            mfg_slug="test-mfg",
+            dt_slug="test-dt",
+            make="TestMake",
+            model="TestModel",
+            source_id="2",
+            device_name="test-device-02",
+            serial="",
+            asset_tag="",
+            DeviceType=DeviceType,
+            Device=Device,
+        )
+        self.assertIn("RACK-99 (not found)", result_row.detail)
+
+
+class EnsureDeviceTypeExecuteModeTest(TestCase):
+    """Tests that _ensure_device_type never appends RowResult rows in execute mode."""
+
+    def setUp(self):
+        self.profile = _make_profile("EnsureDT")
+
+    def test_execute_mode_no_row_results_create_missing_false(self):
+        """Execute mode with create_missing_device_types=False appends no RowResult rows."""
+        from dcim.models import DeviceType, Manufacturer
+
+        from netbox_data_import.engine import ImportResult, _ensure_device_type
+
+        self.profile.create_missing_device_types = False
+        result = ImportResult()
+        row = {"_row_number": 1, "source_id": "1"}
+        _ensure_device_type(
+            "unknown-mfg",
+            "unknown-dt",
+            "Unknown Make",
+            "Unknown Model",
+            1,
+            set(),
+            self.profile,
+            result,
+            dry_run=False,
+            row=row,
+            Manufacturer=Manufacturer,
+            DeviceType=DeviceType,
+        )
+        device_type_rows = [r for r in result.rows if r.object_type == "device_type"]
+        self.assertEqual(device_type_rows, [], "Execute mode must not append device_type RowResult rows")
+
+    def test_execute_mode_no_row_results_create_missing_true(self):
+        """Execute mode with create_missing_device_types=True appends no RowResult rows (creates silently)."""
+        from dcim.models import DeviceType, Manufacturer
+
+        from netbox_data_import.engine import ImportResult, _ensure_device_type
+
+        self.profile.create_missing_device_types = True
+        result = ImportResult()
+        row = {"_row_number": 1, "source_id": "1"}
+        _ensure_device_type(
+            "silent-mfg",
+            "silent-dt",
+            "Silent Make",
+            "Silent Model",
+            1,
+            set(),
+            self.profile,
+            result,
+            dry_run=False,
+            row=row,
+            Manufacturer=Manufacturer,
+            DeviceType=DeviceType,
+        )
+        device_type_rows = [r for r in result.rows if r.object_type == "device_type"]
+        self.assertEqual(device_type_rows, [], "Execute mode must not append device_type RowResult rows")
+        # Verify the device type was actually created in DB
+        self.assertTrue(DeviceType.objects.filter(manufacturer__slug="silent-mfg", slug="silent-dt").exists())
+
+    def test_dry_run_appends_error_row_when_create_missing_false(self):
+        """Dry-run with create_missing_device_types=False does append an error RowResult."""
+        from dcim.models import DeviceType, Manufacturer
+
+        from netbox_data_import.engine import ImportResult, _ensure_device_type
+
+        self.profile.create_missing_device_types = False
+        result = ImportResult()
+        row = {"_row_number": 1, "source_id": "1"}
+        _ensure_device_type(
+            "dry-mfg",
+            "dry-dt",
+            "Dry Make",
+            "Dry Model",
+            1,
+            set(),
+            self.profile,
+            result,
+            dry_run=True,
+            row=row,
+            Manufacturer=Manufacturer,
+            DeviceType=DeviceType,
+        )
+        device_type_rows = [r for r in result.rows if r.object_type == "device_type"]
+        self.assertEqual(len(device_type_rows), 1)
+        self.assertEqual(device_type_rows[0].action, "error")

--- a/netbox_data_import/tests/test_engine_extended.py
+++ b/netbox_data_import/tests/test_engine_extended.py
@@ -258,9 +258,12 @@ class ResolveDeviceTypeSlugsTest(TestCase):
         )
         # Extra spaces in source
         mfg_slug, dt_slug, explicit = _resolve_device_type_slugs("HP", "ProLiant  DL360", self.profile)
-        # May or may not match depending on normalization; just verify no crash
-        self.assertIsInstance(mfg_slug, str)
-        self.assertIsInstance(dt_slug, str)
+        # The fallback normalization only normalizes the stored value, not the input,
+        # so the double-space input won't find the explicit mapping — it falls back to auto-slug.
+        # Coincidentally slugify("HP") == "hp" and slugify("HP-ProLiant  DL360") == "hp-proliant-dl360".
+        self.assertEqual(mfg_slug, "hp")
+        self.assertEqual(dt_slug, "hp-proliant-dl360")
+        self.assertFalse(explicit)  # no explicit mapping found due to un-normalized input
 
 
 class ColumnTransformRuleTest(TestCase):
@@ -1462,13 +1465,15 @@ class Pass1UHeightParseErrorTest(TestCase):
 
     def setUp(self):
         """Set up profile with a device class mapping."""
-        from dcim.models import Site
+        from dcim.models import DeviceRole, Site
 
         self.site = Site.objects.create(name="UHSite", slug="uh-site")
         self.profile = _make_profile("UHProfile")
+        DeviceRole.objects.get_or_create(slug="server", defaults={"name": "Server", "color": "9e9e9e"})
 
     def test_invalid_u_height_falls_back_to_one(self):
         """A row with a non-numeric u_height uses 1 as fallback without error."""
+        from dcim.models import DeviceType
 
         rows = [
             {
@@ -1486,9 +1491,12 @@ class Pass1UHeightParseErrorTest(TestCase):
                 "status": "active",
             }
         ]
-        result = run_import(rows, self.profile, {"site": self.site}, dry_run=True)
-        # Should produce a create row, not crash
+        result = run_import(rows, self.profile, {"site": self.site}, dry_run=False)
         self.assertIsInstance(result, ImportResult)
+        # Verify the DeviceType was created with u_height=1 (the fallback value)
+        dt = DeviceType.objects.filter(slug="uhmake-uhmodel").first()
+        self.assertIsNotNone(dt, "DeviceType should have been created")
+        self.assertEqual(dt.u_height, 1)
 
 
 class PreviewInvalidPositionTest(TestCase):
@@ -1562,8 +1570,11 @@ class Pass3InvalidPositionTest(TestCase):
             }
         ]
         result = run_import(rows, self.profile, {"site": self.site}, dry_run=False)
-        # Should not crash; device row should be in result
+        # Should not crash; device row should be in result with the expected source_id
         self.assertIsInstance(result, ImportResult)
+        device_rows = [r for r in result.rows if r.object_type == "device"]
+        self.assertGreater(len(device_rows), 0, "Expected at least one device row in result")
+        self.assertEqual(device_rows[0].source_id, "P3IP001")
 
 
 class ImportResultRackGroupsTest(TestCase):
@@ -1639,11 +1650,12 @@ class StoreSourceIdTest(TestCase):
         )
 
     def test_store_source_id_with_custom_field_name(self):
-        """_store_source_id with profile.custom_field_name set attempts to write to custom field."""
+        """_store_source_id with profile.custom_field_name set writes to that custom field."""
         from netbox_data_import.engine import _store_source_id
 
-        # Even if the custom field doesn't exist, should not crash
         _store_source_id(self.device, self.profile, "SSI-001")
+        self.device.refresh_from_db()
+        self.assertEqual(self.device.custom_field_data.get("cans_id"), "SSI-001")
 
     def test_store_source_id_no_custom_field_name(self):
         """_store_source_id without custom_field_name still writes data_import_source."""
@@ -1652,6 +1664,9 @@ class StoreSourceIdTest(TestCase):
         self.profile.custom_field_name = ""
         self.profile.save()
         _store_source_id(self.device, self.profile, "SSI-002")
+        self.device.refresh_from_db()
+        dis = self.device.custom_field_data.get("data_import_source", {})
+        self.assertEqual(dis.get("source_id"), "SSI-002")
 
 
 class PreviewMatchedBySerialTest(TestCase):

--- a/netbox_data_import/tests/test_engine_extended.py
+++ b/netbox_data_import/tests/test_engine_extended.py
@@ -1522,8 +1522,8 @@ class PreviewInvalidPositionTest(TestCase):
         result = run_import(rows, self.profile, {"site": self.site}, dry_run=True)
         # No crash — device row exists, position is None so no U-label in detail
         device_rows = [r for r in result.rows if r.object_type == "device"]
-        if device_rows:
-            self.assertNotIn("UNone", device_rows[0].detail)
+        self.assertGreater(len(device_rows), 0, "Expected at least one device row in result")
+        self.assertNotIn("UNone", device_rows[0].detail)
 
 
 class Pass3InvalidPositionTest(TestCase):
@@ -1705,9 +1705,9 @@ class PreviewMatchedBySerialTest(TestCase):
         ]
         result = run_import(rows, self.profile, {"site": self.site}, dry_run=True)
         device_rows = [r for r in result.rows if r.object_type == "device"]
-        if device_rows:
-            self.assertEqual(device_rows[0].action, "update")
-            self.assertIn("serial", device_rows[0].detail)
+        self.assertGreater(len(device_rows), 0, "Expected at least one device row in result")
+        self.assertEqual(device_rows[0].action, "update")
+        self.assertIn("serial", device_rows[0].detail)
 
 
 class DeviceExistingMatchPrecedenceTest(TestCase):

--- a/netbox_data_import/tests/test_engine_extended.py
+++ b/netbox_data_import/tests/test_engine_extended.py
@@ -1708,3 +1708,92 @@ class PreviewMatchedBySerialTest(TestCase):
         if device_rows:
             self.assertEqual(device_rows[0].action, "update")
             self.assertIn("serial", device_rows[0].detail)
+
+
+class DeviceExistingMatchPrecedenceTest(TestCase):
+    """Regression test: DeviceExistingMatch (source_id link) must take precedence
+    over a coincidental same-name device in the same site (engine.py lookup order fix)."""
+
+    def setUp(self):
+        """Create two devices: one linked via DeviceExistingMatch, one with the same name as the source row."""
+        from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
+
+        from netbox_data_import.models import DeviceExistingMatch
+
+        self.site = Site.objects.create(name="DEMPSite", slug="demp-site")
+        mfg = Manufacturer.objects.create(name="DEMPMfg", slug="dempmfg")
+        dt = DeviceType.objects.create(manufacturer=mfg, model="DEMPModel", slug="dempmfg-dempmodel", u_height=1)
+        role = DeviceRole.objects.create(name="DEMPRole", slug="demp-role")
+
+        # Device the source row SHOULD be linked to (via DeviceExistingMatch)
+        self.linked_device = Device.objects.create(name="linked-prod-server", device_type=dt, role=role, site=self.site)
+        # Device that coincidentally shares the source row's device_name
+        self.coincidental_device = Device.objects.create(
+            name="source-row-name", device_type=dt, role=role, site=self.site
+        )
+
+        self.profile = _make_profile("DEMPProfile")
+        self.profile.update_existing = True
+        self.profile.save()
+        # update_or_create: _make_profile already creates source_class="Server"
+        ClassRoleMapping.objects.update_or_create(
+            profile=self.profile,
+            source_class="Server",
+            defaults={"creates_rack": False, "role_slug": "demp-role"},
+        )
+        DeviceExistingMatch.objects.create(
+            profile=self.profile,
+            source_id="DEMP-SRC001",
+            netbox_device_id=self.linked_device.pk,
+            device_name=self.linked_device.name,
+        )
+
+    def test_preview_prefers_explicit_match_over_name(self):
+        """run_import dry_run must report the DeviceExistingMatch device, not the coincidental name match."""
+        rows = [
+            {
+                "_row_number": 1,
+                "source_id": "DEMP-SRC001",
+                "device_name": "source-row-name",  # matches coincidental_device by name
+                "device_class": "Server",
+                "make": "DEMPMfg",
+                "model": "DEMPModel",
+                "u_height": "1",
+                "rack_name": "",
+                "u_position": "",
+                "serial": "",
+                "asset_tag": "",
+                "status": "active",
+            }
+        ]
+        result = run_import(rows, self.profile, {"site": self.site}, dry_run=True)
+        device_rows = [r for r in result.rows if r.object_type == "device"]
+        self.assertEqual(len(device_rows), 1)
+        # Must be linked to linked_device via explicit DeviceExistingMatch, NOT coincidental name
+        self.assertIn("linked-prod-server", device_rows[0].detail)
+        self.assertIn("source ID link", device_rows[0].detail)
+
+    def test_execute_prefers_explicit_match_over_name(self):
+        """run_import (execute mode) must update the DeviceExistingMatch device, not the coincidental name match."""
+        rows = [
+            {
+                "_row_number": 1,
+                "source_id": "DEMP-SRC001",
+                "device_name": "source-row-name",  # matches coincidental_device by name
+                "device_class": "Server",
+                "make": "DEMPMfg",
+                "model": "DEMPModel",
+                "u_height": "1",
+                "rack_name": "",
+                "u_position": "",
+                "serial": "",
+                "asset_tag": "",
+                "status": "active",
+            }
+        ]
+        result = run_import(rows, self.profile, {"site": self.site}, dry_run=False)
+        device_rows = [r for r in result.rows if r.object_type == "device"]
+        self.assertEqual(len(device_rows), 1)
+        self.assertEqual(device_rows[0].action, "update")
+        # The updated device must be linked_device, not coincidental_device
+        self.assertIn("linked-prod-server", device_rows[0].detail)

--- a/netbox_data_import/tests/test_engine_extended.py
+++ b/netbox_data_import/tests/test_engine_extended.py
@@ -559,6 +559,23 @@ class ApplyTransformRulesTest(TestCase):
         _apply_transform_rules(row_dict, raw_row, raw_headers, [rule])
         self.assertEqual(row_dict["device_name"], "unchanged")
 
+    def test_invalid_regex_raises_parse_error(self):
+        """_apply_transform_rules with a malformed regex pattern raises ParseError."""
+        from netbox_data_import.engine import ParseError
+
+        rule = ColumnTransformRule.objects.create(
+            profile=self.profile,
+            source_column="ColF",
+            pattern="(",  # unclosed group — invalid regex
+            group_1_target="device_name",
+            group_2_target="",
+        )
+        row_dict = {}
+        raw_headers = {"ColF": 0}
+        raw_row = ("some value",)
+        with self.assertRaises(ParseError):
+            _apply_transform_rules(row_dict, raw_row, raw_headers, [rule])
+
 
 # ---------------------------------------------------------------------------
 # New tests: FindExistingDeviceTest
@@ -657,6 +674,44 @@ class FindExistingDeviceTest(TestCase):
         matched, method = _find_existing_device(
             self.profile, None, self.site, "no-such-dev", "SN_NOSUCH", "AT_NOSUCH", Device
         )
+        self.assertIsNone(matched)
+        self.assertIsNone(method)
+
+    def test_name_match_with_site(self):
+        """_find_existing_device returns (device, 'name') when matching by device name + site."""
+        from dcim.models import Device
+
+        device = Device.objects.create(
+            name="fed-dev-byname",
+            site=self.site,
+            device_type=self.dt,
+            role=self.role,
+        )
+        matched, method = _find_existing_device(self.profile, None, self.site, "fed-dev-byname", None, None, Device)
+        self.assertEqual(matched, device)
+        self.assertEqual(method, "name")
+
+    def test_name_match_without_site(self):
+        """_find_existing_device returns (device, 'name') when site=None (global name match)."""
+        from dcim.models import Device
+
+        device = Device.objects.create(
+            name="fed-dev-global",
+            site=self.site,
+            device_type=self.dt,
+            role=self.role,
+        )
+        matched, method = _find_existing_device(self.profile, None, None, "fed-dev-global", None, None, Device)
+        self.assertEqual(matched, device)
+        self.assertEqual(method, "name")
+
+    def test_name_match_multiple_objects_returns_none(self):
+        """_find_existing_device returns (None, None) when name matches multiple devices."""
+        from dcim.models import Device
+        from unittest.mock import patch
+
+        with patch.object(Device.objects, "get", side_effect=Device.MultipleObjectsReturned):
+            matched, method = _find_existing_device(self.profile, None, None, "dup-name", None, None, Device)
         self.assertIsNone(matched)
         self.assertIsNone(method)
 
@@ -1106,5 +1161,550 @@ class Pass1UnmappedClassTest(TestCase):
             }
         ]
         before = Manufacturer.objects.count()
-        run_import(rows, self.profile, {"site": self.site}, dry_run=True)
+        run_import(rows, self.profile, {"site": self.site}, dry_run=False)
         self.assertEqual(Manufacturer.objects.count(), before)
+
+
+# ---------------------------------------------------------------------------
+# Additional engine coverage tests
+# ---------------------------------------------------------------------------
+
+
+class EnsureManufacturerEdgeCaseTest(TestCase):
+    """Tests for _ensure_manufacturer seen-manufacturers early return and execute mode."""
+
+    def setUp(self):
+        """Create a profile."""
+        self.profile = _make_profile("EMECProfile")
+
+    def test_seen_manufacturer_skips(self):
+        """_ensure_manufacturer is a no-op when mfg_slug already in seen_manufacturers."""
+        from netbox_data_import.engine import _ensure_manufacturer, ImportResult
+        from dcim.models import Manufacturer
+
+        result = ImportResult()
+        seen = {"already-seen"}
+        before = Manufacturer.objects.count()
+        _ensure_manufacturer(
+            "already-seen", "AlreadySeen", seen, self.profile, result, True, {"_row_number": 1}, Manufacturer
+        )
+        self.assertEqual(Manufacturer.objects.count(), before)
+        self.assertEqual(len(result.rows), 0)
+
+    def test_execute_mode_creates_manufacturer(self):
+        """_ensure_manufacturer creates manufacturer in execute mode when flag is set."""
+        from netbox_data_import.engine import _ensure_manufacturer, ImportResult
+        from dcim.models import Manufacturer
+
+        self.profile.create_missing_device_types = True
+        self.profile.save()
+        result = ImportResult()
+        seen = set()
+        _ensure_manufacturer(
+            "exec-mfg-slug", "Exec Mfg", seen, self.profile, result, False, {"_row_number": 1}, Manufacturer
+        )
+        self.assertTrue(Manufacturer.objects.filter(slug="exec-mfg-slug").exists())
+
+    def test_execute_mode_skips_when_flag_false(self):
+        """_ensure_manufacturer is a no-op in execute mode when create_missing_device_types=False."""
+        from netbox_data_import.engine import _ensure_manufacturer, ImportResult
+        from dcim.models import Manufacturer
+
+        self.profile.create_missing_device_types = False
+        self.profile.save()
+        result = ImportResult()
+        seen = set()
+        before = Manufacturer.objects.count()
+        _ensure_manufacturer(
+            "no-create-mfg", "No Create Mfg", seen, self.profile, result, False, {"_row_number": 1}, Manufacturer
+        )
+        self.assertEqual(Manufacturer.objects.count(), before)
+
+
+class EnsureDeviceTypeEdgeCaseTest(TestCase):
+    """Tests for _ensure_device_type seen-types early return and existing-type path."""
+
+    def setUp(self):
+        """Create a profile and a manufacturer."""
+        from dcim.models import Manufacturer
+
+        self.profile = _make_profile("EDTECProfile")
+        self.mfg = Manufacturer.objects.create(name="EDTEC Mfg", slug="edtec-mfg")
+
+    def test_seen_device_type_skips(self):
+        """_ensure_device_type is a no-op when the (mfg,dt) key already in seen_device_types."""
+        from netbox_data_import.engine import _ensure_device_type, ImportResult
+        from dcim.models import Manufacturer, DeviceType
+
+        result = ImportResult()
+        seen = {("edtec-mfg", "edtec-seen")}
+        before = DeviceType.objects.count()
+        _ensure_device_type(
+            "edtec-mfg",
+            "edtec-seen",
+            "EDTEC",
+            "Seen",
+            1,
+            seen,
+            self.profile,
+            result,
+            True,
+            {"_row_number": 1},
+            Manufacturer,
+            DeviceType,
+        )
+        self.assertEqual(DeviceType.objects.count(), before)
+        self.assertEqual(len(result.rows), 0)
+
+    def test_dry_run_existing_dt_no_rows_appended(self):
+        """In dry_run, when DeviceType already exists, no rows are appended."""
+        from netbox_data_import.engine import _ensure_device_type, ImportResult
+        from dcim.models import Manufacturer, DeviceType
+
+        DeviceType.objects.get_or_create(
+            manufacturer=self.mfg, slug="edtec-exists", defaults={"model": "Exists", "u_height": 1}
+        )
+        result = ImportResult()
+        seen: set = set()
+        _ensure_device_type(
+            "edtec-mfg",
+            "edtec-exists",
+            "EDTEC",
+            "Exists",
+            1,
+            seen,
+            self.profile,
+            result,
+            True,
+            {"_row_number": 1},
+            Manufacturer,
+            DeviceType,
+        )
+        self.assertEqual(len(result.rows), 0)
+
+
+class EnsureDeviceRoleEdgeCaseTest(TestCase):
+    """Tests for _ensure_device_role early-return paths."""
+
+    def setUp(self):
+        """Create a profile and CRM."""
+        from dcim.models import Site
+
+        self.profile = _make_profile("EDRECProfile")
+        self.site = Site.objects.create(name="EDRSite", slug="edr-site")
+
+    def test_no_crm_skips(self):
+        """_ensure_device_role is a no-op when crm is None."""
+        from netbox_data_import.engine import _ensure_device_role
+        from dcim.models import DeviceRole
+
+        seen: set = set()
+        before = DeviceRole.objects.count()
+        _ensure_device_role(None, seen, False, DeviceRole)
+        self.assertEqual(DeviceRole.objects.count(), before)
+
+    def test_crm_no_role_slug_skips(self):
+        """_ensure_device_role is a no-op when crm has no role_slug."""
+        from netbox_data_import.engine import _ensure_device_role
+        from dcim.models import DeviceRole
+        from netbox_data_import.models import ClassRoleMapping
+
+        crm = ClassRoleMapping.objects.create(
+            profile=self.profile, source_class="NoRoleClass", creates_rack=False, role_slug=""
+        )
+        seen: set = set()
+        before = DeviceRole.objects.count()
+        _ensure_device_role(crm, seen, False, DeviceRole)
+        self.assertEqual(DeviceRole.objects.count(), before)
+
+    def test_already_seen_role_skips(self):
+        """_ensure_device_role is a no-op when role_slug already in seen_roles."""
+        from netbox_data_import.engine import _ensure_device_role
+        from dcim.models import DeviceRole
+        from netbox_data_import.models import ClassRoleMapping
+
+        crm = ClassRoleMapping.objects.create(
+            profile=self.profile, source_class="SeenRoleClass", creates_rack=False, role_slug="seen-role"
+        )
+        seen = {"seen-role"}
+        before = DeviceRole.objects.count()
+        _ensure_device_role(crm, seen, False, DeviceRole)
+        self.assertEqual(DeviceRole.objects.count(), before)
+
+    def test_execute_creates_role(self):
+        """_ensure_device_role creates a DeviceRole in execute mode."""
+        from netbox_data_import.engine import _ensure_device_role
+        from dcim.models import DeviceRole
+        from netbox_data_import.models import ClassRoleMapping
+
+        crm = ClassRoleMapping.objects.create(
+            profile=self.profile, source_class="NewRoleClass", creates_rack=False, role_slug="new-unique-role-edr"
+        )
+        seen: set = set()
+        _ensure_device_role(crm, seen, False, DeviceRole)
+        self.assertTrue(DeviceRole.objects.filter(slug="new-unique-role-edr").exists())
+
+
+class Pass2EdgeCasesTest(TestCase):
+    """Test _pass2_process_racks edge cases (missing rack_name, u_height parse error)."""
+
+    def setUp(self):
+        """Create site and profile."""
+        from dcim.models import Site
+
+        self.site = Site.objects.create(name="P2EdgeSite", slug="p2-edge-site")
+        self.profile = _make_profile("P2EdgeProfile")
+
+    def test_missing_rack_name_records_error(self):
+        """A rack row with empty rack_name records an error row."""
+        from netbox_data_import.models import ClassRoleMapping
+
+        # Profile needs a rack-creating class
+        self.profile.class_role_mappings.all().delete()
+        ClassRoleMapping.objects.create(profile=self.profile, source_class="RackClass", creates_rack=True)
+
+        rows = [
+            {
+                "_row_number": 1,
+                "source_id": "RACK001",
+                "device_class": "RackClass",
+                "rack_name": "",
+                "u_height": "42",
+                "serial": "",
+            }
+        ]
+        result = run_import(rows, self.profile, {"site": self.site}, dry_run=True)
+        error_rows = [r for r in result.rows if r.action == "error" and r.object_type == "rack"]
+        self.assertEqual(len(error_rows), 1)
+
+    def test_invalid_u_height_uses_default(self):
+        """A rack row with invalid u_height uses default (42) without crashing."""
+        from netbox_data_import.models import ClassRoleMapping
+        from dcim.models import Rack
+
+        self.profile.class_role_mappings.all().delete()
+        ClassRoleMapping.objects.create(profile=self.profile, source_class="RackClass2", creates_rack=True)
+
+        rows = [
+            {
+                "_row_number": 1,
+                "source_id": "RACK002",
+                "device_class": "RackClass2",
+                "rack_name": "P2EdgeRack",
+                "u_height": "not-a-number",
+                "serial": "",
+            }
+        ]
+        run_import(rows, self.profile, {"site": self.site}, dry_run=False)
+        rack = Rack.objects.filter(site=self.site, name="P2EdgeRack").first()
+        self.assertIsNotNone(rack)
+        self.assertEqual(rack.u_height, 42)
+
+
+class Pass3PositionUnderRackTest(TestCase):
+    """Test _pass3_process_devices with position < 1 (blanking panel skip)."""
+
+    def setUp(self):
+        """Create site and profile with device class mapping."""
+        from dcim.models import Site
+
+        self.site = Site.objects.create(name="P3PosEdge", slug="p3-pos-edge")
+        self.profile = _make_profile("P3PosProfile")
+
+    def test_position_zero_produces_skip(self):
+        """A device row with u_position=0 is skipped (blanking panel)."""
+        rows = [
+            {
+                "_row_number": 1,
+                "source_id": "POS001",
+                "device_name": "blanking-panel",
+                "device_class": "Server",
+                "make": "Dell",
+                "model": "R740",
+                "u_height": "1",
+                "rack_name": "",
+                "u_position": "0",
+                "serial": "",
+                "asset_tag": "",
+                "status": "active",
+            }
+        ]
+        result = run_import(rows, self.profile, {"site": self.site}, dry_run=True)
+        skip_rows = [r for r in result.rows if r.action == "skip" and r.object_type == "device"]
+        self.assertEqual(len(skip_rows), 1)
+
+
+class FindExistingDeviceDeletedMatchTest(TestCase):
+    """Test _find_existing_device when the linked device has been deleted."""
+
+    def setUp(self):
+        """Create profile for match tests."""
+        self.profile = ImportProfile.objects.create(name="DELMatchProfile", sheet_name="Data", source_id_column="Id")
+
+    def test_deleted_device_match_falls_through(self):
+        """When source-ID match points to a non-existent device PK, returns (None, None)."""
+        from dcim.models import Device
+        from netbox_data_import.models import DeviceExistingMatch
+
+        DeviceExistingMatch.objects.create(
+            profile=self.profile,
+            source_id="DEL001",
+            netbox_device_id=999999,  # non-existent PK
+            device_name="gone",
+        )
+        matched, method = _find_existing_device(self.profile, "DEL001", None, None, None, None, Device)
+        self.assertIsNone(matched)
+        self.assertIsNone(method)
+
+
+class Pass1UHeightParseErrorTest(TestCase):
+    """Test _pass1_ensure_types u_height parse error (lines 400-401)."""
+
+    def setUp(self):
+        """Set up profile with a device class mapping."""
+        from dcim.models import Site
+
+        self.site = Site.objects.create(name="UHSite", slug="uh-site")
+        self.profile = _make_profile("UHProfile")
+
+    def test_invalid_u_height_falls_back_to_one(self):
+        """A row with a non-numeric u_height uses 1 as fallback without error."""
+
+        rows = [
+            {
+                "_row_number": 1,
+                "source_id": "UH001",
+                "device_name": "uh-dev-01",
+                "device_class": "Server",
+                "make": "UHMake",
+                "model": "UHModel",
+                "u_height": "not-a-number",
+                "rack_name": "",
+                "u_position": "1",
+                "serial": "",
+                "asset_tag": "",
+                "status": "active",
+            }
+        ]
+        result = run_import(rows, self.profile, {"site": self.site}, dry_run=True)
+        # Should produce a create row, not crash
+        self.assertIsInstance(result, ImportResult)
+
+
+class PreviewInvalidPositionTest(TestCase):
+    """Test _preview_device_row with invalid u_position (lines 652-653)."""
+
+    def setUp(self):
+        """Set up profile and site."""
+        from dcim.models import Site
+
+        self.site = Site.objects.create(name="PIPSite", slug="pip-site")
+        self.profile = _make_profile("PIPProfile")
+
+    def test_invalid_position_in_preview(self):
+        """A device row with a non-numeric u_position does not crash in preview."""
+        rows = [
+            {
+                "_row_number": 1,
+                "source_id": "PIP001",
+                "device_name": "pip-dev-01",
+                "device_class": "Server",
+                "make": "PIPMake",
+                "model": "PIPModel",
+                "u_height": "1",
+                "rack_name": "",
+                "u_position": "invalid-pos",
+                "serial": "",
+                "asset_tag": "",
+                "status": "active",
+            }
+        ]
+        result = run_import(rows, self.profile, {"site": self.site}, dry_run=True)
+        # No crash — device row exists, position is None so no U-label in detail
+        device_rows = [r for r in result.rows if r.object_type == "device"]
+        if device_rows:
+            self.assertNotIn("UNone", device_rows[0].detail)
+
+
+class Pass3InvalidPositionTest(TestCase):
+    """Test _pass3_process_devices with invalid u_position string (lines 853-854)."""
+
+    def setUp(self):
+        """Set up site and profile."""
+        from dcim.models import Site, Manufacturer, DeviceType, DeviceRole
+
+        self.site = Site.objects.create(name="P3IPSite", slug="p3-ip-site")
+        self.profile = _make_profile("P3IPProfile")
+        mfg = Manufacturer.objects.create(name="P3IPMfg", slug="p3ipmfg")
+        self.dt = DeviceType.objects.create(manufacturer=mfg, model="P3IPModel", slug="p3ipmfg-p3ipmodel")
+        DeviceRole.objects.get_or_create(slug="server", defaults={"name": "Server", "color": "9e9e9e"})
+
+    def test_invalid_position_produces_device_row(self):
+        """A device row with non-numeric u_position (line 853-854 TypeError path) processes without crash."""
+
+        self.profile.create_missing_device_types = True
+        self.profile.save()
+
+        rows = [
+            {
+                "_row_number": 1,
+                "source_id": "P3IP001",
+                "device_name": "p3ip-dev-01",
+                "device_class": "Server",
+                "make": "P3IPMfg",
+                "model": "P3IPModel",
+                "u_height": "1",
+                "rack_name": "",
+                "u_position": "not-a-number",
+                "serial": "",
+                "asset_tag": "",
+                "status": "active",
+            }
+        ]
+        result = run_import(rows, self.profile, {"site": self.site}, dry_run=False)
+        # Should not crash; device row should be in result
+        self.assertIsInstance(result, ImportResult)
+
+
+class ImportResultRackGroupsTest(TestCase):
+    """Test ImportResult.rack_groups property (line 113 — 'else' branch)."""
+
+    def test_rack_groups_duplicate_rack_name(self):
+        """rack_groups updates existing rack when the same name appears twice."""
+        r1 = RowResult(row_number=1, source_id="R1", name="RackA", action="update", object_type="rack", detail="")
+        r2 = RowResult(row_number=2, source_id="R2", name="RackA", action="create", object_type="rack", detail="")
+
+        result = ImportResult()
+        result.rows = [r1, r2]
+        groups = result.rack_groups
+        # Both rack rows for "RackA"; the second should overwrite rack_row for "RackA"
+        self.assertIn("RackA", groups)
+        self.assertEqual(groups["RackA"]["rack_row"], r2)
+
+
+class ResolveDeviceTypeSlugsNormalizeTest(TestCase):
+    """Test _resolve_device_type_slugs normalizer loops (lines 241-242, 251-252)."""
+
+    def setUp(self):
+        """Create profile and a device type mapping with unicode escape in model."""
+        self.profile = ImportProfile.objects.create(name="DTSNProfile", sheet_name="Data", source_id_column="Id")
+
+    def test_unicode_escape_in_model_matches(self):
+        """DeviceTypeMapping with extra whitespace in source_model is matched after normalization (lines 241-242)."""
+        from netbox_data_import.engine import _resolve_device_type_slugs
+        from netbox_data_import.models import DeviceTypeMapping
+
+        DeviceTypeMapping.objects.create(
+            profile=self.profile,
+            source_make="TestMake",
+            source_model="Model  X",  # double internal space — doesn't match direct lookup
+            netbox_manufacturer_slug="testmake",
+            netbox_device_type_slug="testmake-modelx",
+        )
+        # Direct lookup uses single-space "Model X" — won't match "Model  X" directly
+        mfg_slug, dt_slug, is_explicit = _resolve_device_type_slugs("TestMake", "Model X", self.profile)
+        self.assertEqual(mfg_slug, "testmake")
+        self.assertEqual(dt_slug, "testmake-modelx")
+        self.assertTrue(is_explicit)
+
+    def test_manufacturer_mapping_normalizer_loop(self):
+        """ManufacturerMapping with JS-style \\uXXXX in source_make is matched after normalization."""
+        from netbox_data_import.engine import _resolve_device_type_slugs
+        from netbox_data_import.models import ManufacturerMapping
+
+        ManufacturerMapping.objects.create(
+            profile=self.profile,
+            source_make="Vendor\\u0020Corp",  # \u0020 is space
+            netbox_manufacturer_slug="vendor-corp",
+        )
+        mfg_slug, dt_slug, is_explicit = _resolve_device_type_slugs("Vendor Corp", "ModelZ", self.profile)
+        self.assertEqual(mfg_slug, "vendor-corp")
+        self.assertFalse(is_explicit)
+
+
+class StoreSourceIdTest(TestCase):
+    """Tests for _store_source_id function (lines 1006-1027)."""
+
+    def setUp(self):
+        """Create a profile and device."""
+        from dcim.models import Site, Manufacturer, DeviceType, DeviceRole, Device
+
+        self.site = Site.objects.create(name="SSISite", slug="ssi-site")
+        mfg = Manufacturer.objects.create(name="SSIMfg", slug="ssi-mfg")
+        dt = DeviceType.objects.create(manufacturer=mfg, model="SSIModel", slug="ssi-model")
+        role = DeviceRole.objects.create(name="SSIRole", slug="ssi-role")
+        self.device = Device.objects.create(name="ssi-dev", device_type=dt, role=role, site=self.site)
+        self.profile = ImportProfile.objects.create(
+            name="SSIProfile", sheet_name="Data", source_id_column="Id", custom_field_name="cans_id"
+        )
+
+    def test_store_source_id_with_custom_field_name(self):
+        """_store_source_id with profile.custom_field_name set attempts to write to custom field."""
+        from netbox_data_import.engine import _store_source_id
+
+        # Even if the custom field doesn't exist, should not crash
+        _store_source_id(self.device, self.profile, "SSI-001")
+
+    def test_store_source_id_no_custom_field_name(self):
+        """_store_source_id without custom_field_name still writes data_import_source."""
+        from netbox_data_import.engine import _store_source_id
+
+        self.profile.custom_field_name = ""
+        self.profile.save()
+        _store_source_id(self.device, self.profile, "SSI-002")
+
+
+class PreviewMatchedBySerialTest(TestCase):
+    """Test _preview_device_row matched-by-serial path (lines 664-665)."""
+
+    def setUp(self):
+        """Create a device with a serial, profile and site."""
+        from dcim.models import Site, Manufacturer, DeviceType, DeviceRole, Device
+
+        self.site = Site.objects.create(name="PMBSSite", slug="pmbs-site")
+        mfg = Manufacturer.objects.create(name="PMBSMfg", slug="pmbs-mfg")
+        self.dt = DeviceType.objects.create(manufacturer=mfg, model="PMBSModel", slug="pmbs-model")
+        self.role = DeviceRole.objects.create(name="server-pmbs", slug="server-pmbs")
+        # Use a name that won't match directly (force fall-through to _find_existing_device)
+        self.device = Device.objects.create(
+            name="pmbs-dev-existing",
+            device_type=self.dt,
+            role=self.role,
+            site=self.site,
+            serial="PMBS-SN-UNIQUE",
+        )
+        self.profile = _make_profile("PMBSProfile")
+        self.profile.update_existing = True
+        self.profile.save()
+        # Add a CRM for "Server" → server-pmbs (using the profile's built-in mappings)
+        from netbox_data_import.models import ClassRoleMapping
+
+        ClassRoleMapping.objects.get_or_create(
+            profile=self.profile,
+            source_class="PMBS",
+            defaults={"creates_rack": False, "role_slug": "server-pmbs"},
+        )
+
+    def test_preview_matched_by_serial_shows_update(self):
+        """In dry_run, a device with matching serial is shown as 'update' (via _find_existing_device)."""
+        rows = [
+            {
+                "_row_number": 1,
+                "source_id": "PMBS001",
+                "device_name": "different-name",  # won't match by name
+                "device_class": "PMBS",
+                "make": "PMBSMfg",
+                "model": "PMBSModel",
+                "u_height": "1",
+                "rack_name": "",
+                "u_position": "1",
+                "serial": "PMBS-SN-UNIQUE",
+                "asset_tag": "",
+                "status": "active",
+            }
+        ]
+        result = run_import(rows, self.profile, {"site": self.site}, dry_run=True)
+        device_rows = [r for r in result.rows if r.object_type == "device"]
+        if device_rows:
+            self.assertEqual(device_rows[0].action, "update")
+            self.assertIn("serial", device_rows[0].detail)

--- a/netbox_data_import/tests/test_engine_extended.py
+++ b/netbox_data_import/tests/test_engine_extended.py
@@ -6,7 +6,17 @@ import os
 
 from django.test import TestCase
 
-from netbox_data_import.engine import ImportResult, RowResult, _resolve_device_type_slugs, parse_file, run_import
+from netbox_data_import.engine import (
+    ImportResult,
+    RowResult,
+    _apply_transform_rules,
+    _find_existing_device,
+    _resolve_device_type_slugs,
+    _write_device_row,
+    _write_rack_to_db,
+    parse_file,
+    run_import,
+)
 from netbox_data_import.models import (
     ClassRoleMapping,
     ColumnMapping,
@@ -458,3 +468,643 @@ class ManufacturerMappingInEngineTest(TestCase):
             rows = parse_file(f, self.profile)
         result = run_import(rows, self.profile, {"site": self.site}, dry_run=True)
         self.assertIsInstance(result, ImportResult)
+
+
+# ---------------------------------------------------------------------------
+# New tests: ApplyTransformRulesTest
+# ---------------------------------------------------------------------------
+
+
+class ApplyTransformRulesTest(TestCase):
+    """Tests for _apply_transform_rules direct-call behaviour."""
+
+    def setUp(self):
+        """Create a minimal profile for transform rule tests."""
+        self.profile = ImportProfile.objects.create(name="ATRTest", sheet_name="Data", source_id_column="Id")
+
+    def test_group_1_target_set_on_match(self):
+        """When the pattern matches, group_1_target is written to row_dict."""
+        rule = ColumnTransformRule.objects.create(
+            profile=self.profile,
+            source_column="ColA",
+            pattern=r"^(\w+) - .+$",
+            group_1_target="asset_tag",
+            group_2_target="",
+        )
+        row_dict = {}
+        raw_headers = {"ColA": 0}
+        raw_row = ("AT9876 - description",)
+        _apply_transform_rules(row_dict, raw_row, raw_headers, [rule])
+        self.assertEqual(row_dict.get("asset_tag"), "AT9876")
+
+    def test_both_groups_set_on_match(self):
+        """When the pattern matches and both group targets are set, both fields are written."""
+        rule = ColumnTransformRule.objects.create(
+            profile=self.profile,
+            source_column="ColB",
+            pattern=r"^(\w+) - (.+)$",
+            group_1_target="asset_tag",
+            group_2_target="device_name",
+        )
+        row_dict = {}
+        raw_headers = {"ColB": 0}
+        raw_row = ("AT0001 - my-device",)
+        _apply_transform_rules(row_dict, raw_row, raw_headers, [rule])
+        self.assertEqual(row_dict.get("asset_tag"), "AT0001")
+        self.assertEqual(row_dict.get("device_name"), "my-device")
+
+    def test_no_match_leaves_row_dict_unchanged(self):
+        """When the pattern does not match, row_dict is left unchanged."""
+        rule = ColumnTransformRule.objects.create(
+            profile=self.profile,
+            source_column="ColC",
+            pattern=r"^\d{10}$",
+            group_1_target="asset_tag",
+            group_2_target="",
+        )
+        row_dict = {"device_name": "original"}
+        raw_headers = {"ColC": 0}
+        raw_row = ("not-ten-digits",)
+        _apply_transform_rules(row_dict, raw_row, raw_headers, [rule])
+        self.assertNotIn("asset_tag", row_dict)
+        self.assertEqual(row_dict["device_name"], "original")
+
+    def test_missing_column_header_skips_rule(self):
+        """When the source_column is absent from raw_headers, the rule is skipped silently."""
+        rule = ColumnTransformRule.objects.create(
+            profile=self.profile,
+            source_column="ColD",
+            pattern=r"^(.+)$",
+            group_1_target="device_name",
+            group_2_target="",
+        )
+        row_dict = {"device_name": "unchanged"}
+        raw_headers = {}  # ColD not present
+        raw_row = ("some value",)
+        _apply_transform_rules(row_dict, raw_row, raw_headers, [rule])
+        self.assertEqual(row_dict["device_name"], "unchanged")
+
+    def test_none_raw_value_skips_rule(self):
+        """When the raw cell value is None, the rule is skipped silently."""
+        rule = ColumnTransformRule.objects.create(
+            profile=self.profile,
+            source_column="ColE",
+            pattern=r"^(.+)$",
+            group_1_target="device_name",
+            group_2_target="",
+        )
+        row_dict = {"device_name": "unchanged"}
+        raw_headers = {"ColE": 0}
+        raw_row = (None,)  # None value at index 0
+        _apply_transform_rules(row_dict, raw_row, raw_headers, [rule])
+        self.assertEqual(row_dict["device_name"], "unchanged")
+
+
+# ---------------------------------------------------------------------------
+# New tests: FindExistingDeviceTest
+# ---------------------------------------------------------------------------
+
+
+class FindExistingDeviceTest(TestCase):
+    """Unit tests for _find_existing_device matching logic."""
+
+    def setUp(self):
+        """Create a site, device type, role, and profile for matching tests."""
+        from dcim.models import Site, DeviceType, Manufacturer, DeviceRole
+
+        self.site = Site.objects.create(name="FEDSite", slug="fed-site")
+        mfg = Manufacturer.objects.create(name="FED Corp", slug="fed-corp")
+        self.dt = DeviceType.objects.create(manufacturer=mfg, model="FED Model", slug="fed-model")
+        self.role = DeviceRole.objects.create(name="FED Role", slug="fed-role")
+        self.profile = ImportProfile.objects.create(name="FEDProfile", sheet_name="Data", source_id_column="Id")
+
+    def test_source_id_link_match(self):
+        """_find_existing_device returns (device, 'source ID link') when a DeviceExistingMatch exists."""
+        from dcim.models import Device
+        from netbox_data_import.models import DeviceExistingMatch
+
+        device = Device.objects.create(name="fed-dev-01", site=self.site, device_type=self.dt, role=self.role)
+        DeviceExistingMatch.objects.create(
+            profile=self.profile,
+            source_id="FED001",
+            netbox_device_id=device.pk,
+            device_name=device.name,
+        )
+        matched, method = _find_existing_device(self.profile, "FED001", self.site, "other-name", None, None, Device)
+        self.assertEqual(matched, device)
+        self.assertEqual(method, "source ID link")
+
+    def test_serial_match(self):
+        """_find_existing_device returns (device, 'serial') when a device with that serial exists."""
+        from dcim.models import Device
+
+        device = Device.objects.create(
+            name="fed-dev-02",
+            site=self.site,
+            device_type=self.dt,
+            role=self.role,
+            serial="SN_UNIQUE_TEST_99",
+        )
+        matched, method = _find_existing_device(
+            self.profile, None, self.site, "other-name", "SN_UNIQUE_TEST_99", None, Device
+        )
+        self.assertEqual(matched, device)
+        self.assertEqual(method, "serial")
+
+    def test_serial_multiple_objects_returns_none(self):
+        """_find_existing_device returns (None, None) when serial matches multiple devices."""
+        from dcim.models import Device
+        from unittest.mock import patch
+
+        with patch.object(Device.objects, "get", side_effect=Device.MultipleObjectsReturned):
+            matched, method = _find_existing_device(
+                self.profile, None, self.site, "any-name", "AMBIG-SERIAL", None, Device
+            )
+        self.assertIsNone(matched)
+        self.assertIsNone(method)
+
+    def test_asset_tag_match(self):
+        """_find_existing_device returns (device, 'asset tag') when a device with that asset_tag exists."""
+        from dcim.models import Device
+
+        device = Device.objects.create(
+            name="fed-dev-03",
+            site=self.site,
+            device_type=self.dt,
+            role=self.role,
+            asset_tag="AT_UNIQUE_TEST_88",
+        )
+        matched, method = _find_existing_device(
+            self.profile, None, self.site, "other-name", None, "AT_UNIQUE_TEST_88", Device
+        )
+        self.assertEqual(matched, device)
+        self.assertEqual(method, "asset tag")
+
+    def test_asset_tag_multiple_objects_returns_none(self):
+        """_find_existing_device returns (None, None) when asset_tag matches multiple devices."""
+        from dcim.models import Device
+        from unittest.mock import patch
+
+        with patch.object(Device.objects, "get", side_effect=Device.MultipleObjectsReturned):
+            matched, method = _find_existing_device(self.profile, None, self.site, "any-name", None, "AMBIG-AT", Device)
+        self.assertIsNone(matched)
+        self.assertIsNone(method)
+
+    def test_no_match_returns_none(self):
+        """_find_existing_device returns (None, None) when no match is found."""
+        from dcim.models import Device
+
+        matched, method = _find_existing_device(
+            self.profile, None, self.site, "no-such-dev", "SN_NOSUCH", "AT_NOSUCH", Device
+        )
+        self.assertIsNone(matched)
+        self.assertIsNone(method)
+
+
+# ---------------------------------------------------------------------------
+# New tests: WriteRackToDbTest
+# ---------------------------------------------------------------------------
+
+
+class WriteRackToDbTest(TestCase):
+    """Unit tests for _write_rack_to_db: create, update (with location+tenant), and skip."""
+
+    def setUp(self):
+        """Create a site and profile for rack DB write tests."""
+        from dcim.models import Site
+
+        self.site = Site.objects.create(name="WRSite", slug="wr-site")
+        self.profile = ImportProfile.objects.create(name="WRProfile", sheet_name="Data", source_id_column="Id")
+
+    def test_create_new_rack(self):
+        """_write_rack_to_db creates a new Rack and records action='create'."""
+        from dcim.models import Rack
+
+        rack_map = {}
+        result = ImportResult()
+        row = {"_row_number": 1}
+        _write_rack_to_db(
+            "NewRack",
+            self.site,
+            None,
+            None,
+            42,
+            "",
+            self.profile,
+            "SRC1",
+            row,
+            rack_map,
+            result,
+            True,
+            Rack,
+        )
+        self.assertEqual(len(result.rows), 1)
+        self.assertEqual(result.rows[0].action, "create")
+        self.assertTrue(Rack.objects.filter(site=self.site, name="NewRack").exists())
+
+    def test_update_existing_rack_with_location_and_tenant(self):
+        """_write_rack_to_db updates an existing rack and sets location and tenant."""
+        from dcim.models import Rack, Location
+        from tenancy.models import Tenant
+
+        rack = Rack.objects.create(site=self.site, name="ExistRack", u_height=42)
+        loc = Location.objects.create(name="WRLoc", slug="wr-loc", site=self.site)
+        tenant = Tenant.objects.create(name="WRTenant", slug="wr-tenant")
+
+        rack_map = {}
+        result = ImportResult()
+        row = {"_row_number": 2}
+        _write_rack_to_db(
+            "ExistRack",
+            self.site,
+            loc,
+            tenant,
+            24,
+            "SN002",
+            self.profile,
+            "SRC2",
+            row,
+            rack_map,
+            result,
+            True,
+            Rack,
+        )
+        self.assertEqual(result.rows[0].action, "update")
+        rack.refresh_from_db()
+        self.assertEqual(rack.location, loc)
+        self.assertEqual(rack.tenant, tenant)
+        self.assertEqual(rack.u_height, 24)
+
+    def test_skip_existing_rack_when_update_existing_false(self):
+        """_write_rack_to_db records action='skip' when update_existing=False and rack exists."""
+        from dcim.models import Rack
+
+        Rack.objects.create(site=self.site, name="SkipRack", u_height=42)
+        rack_map = {}
+        result = ImportResult()
+        row = {"_row_number": 3}
+        _write_rack_to_db(
+            "SkipRack",
+            self.site,
+            None,
+            None,
+            42,
+            "",
+            self.profile,
+            "SRC3",
+            row,
+            rack_map,
+            result,
+            False,
+            Rack,
+        )
+        self.assertEqual(result.rows[0].action, "skip")
+        self.assertIn("SkipRack", rack_map)
+
+
+# ---------------------------------------------------------------------------
+# New tests: WriteDeviceRowTest
+# ---------------------------------------------------------------------------
+
+
+class WriteDeviceRowTest(TestCase):
+    """Unit tests for _write_device_row: error, create, update, skip paths."""
+
+    def setUp(self):
+        """Create site, manufacturer, device type, device role, profile and CRM."""
+        from dcim.models import Site, Manufacturer, DeviceType, DeviceRole
+
+        self.site = Site.objects.create(name="WDSite", slug="wd-site")
+        self.mfg = Manufacturer.objects.create(name="WD Corp", slug="wd-corp")
+        self.dt = DeviceType.objects.create(manufacturer=self.mfg, model="WD Model", slug="wd-model")
+        self.role = DeviceRole.objects.create(name="WD Role", slug="wd-role")
+        self.profile = ImportProfile.objects.create(
+            name="WDProfile", sheet_name="Data", source_id_column="Id", update_existing=True
+        )
+        self.crm = ClassRoleMapping.objects.create(profile=self.profile, source_class="Server", role_slug="wd-role")
+
+    def _base_row(self, num=1, device_name=None):
+        """Return a minimal synthetic row dict."""
+        return {
+            "_row_number": num,
+            "source_id": f"WD{num:03d}",
+            "device_name": device_name or f"wd-dev-{num:02d}",
+            "device_class": "Server",
+            "make": "WD Corp",
+            "model": "WD Model",
+            "u_height": "1",
+            "rack_name": "",
+            "u_position": "1",
+            "serial": "",
+            "asset_tag": "",
+            "status": "active",
+        }
+
+    def test_device_type_not_found_returns_error(self):
+        """_write_device_row returns action='error' when DeviceType does not exist."""
+        from dcim.models import Device, DeviceType, DeviceRole, Rack
+
+        row = self._base_row(1)
+        result = _write_device_row(
+            row,
+            self.profile,
+            self.site,
+            None,
+            None,
+            {},
+            "WD Corp",
+            "WD Model",
+            self.crm,
+            "nonexistent-mfg",
+            "nonexistent-dt",
+            "WD001",
+            "wd-dev-01",
+            "",
+            None,
+            1,
+            None,
+            None,
+            "active",
+            DeviceType,
+            DeviceRole,
+            Rack,
+            Device,
+        )
+        self.assertEqual(result.action, "error")
+        self.assertIn("not found", result.detail)
+
+    def test_device_role_not_found_returns_error(self):
+        """_write_device_row returns action='error' when DeviceRole does not exist."""
+        from dcim.models import Device, DeviceType, DeviceRole, Rack
+
+        crm_bad = ClassRoleMapping.objects.create(
+            profile=self.profile, source_class="BadRole", role_slug="nonexistent-role"
+        )
+        row = self._base_row(2)
+        result = _write_device_row(
+            row,
+            self.profile,
+            self.site,
+            None,
+            None,
+            {},
+            "WD Corp",
+            "WD Model",
+            crm_bad,
+            "wd-corp",
+            "wd-model",
+            "WD002",
+            "wd-dev-02",
+            "",
+            None,
+            1,
+            None,
+            None,
+            "active",
+            DeviceType,
+            DeviceRole,
+            Rack,
+            Device,
+        )
+        self.assertEqual(result.action, "error")
+        self.assertIn("not found", result.detail)
+
+    def test_create_device_successfully(self):
+        """_write_device_row creates a Device and returns action='create' with correct detail."""
+        from dcim.models import Device, DeviceType, DeviceRole, Rack
+
+        row = self._base_row(3)
+        result = _write_device_row(
+            row,
+            self.profile,
+            self.site,
+            None,
+            None,
+            {},
+            "WD Corp",
+            "WD Model",
+            self.crm,
+            "wd-corp",
+            "wd-model",
+            "WD003",
+            "wd-dev-03",
+            "",
+            None,
+            1,
+            None,
+            None,
+            "active",
+            DeviceType,
+            DeviceRole,
+            Rack,
+            Device,
+        )
+        self.assertEqual(result.action, "create")
+        self.assertNotIn("  ", result.detail)  # no double space
+        self.assertTrue(Device.objects.filter(site=self.site, name="wd-dev-03").exists())
+
+    def test_update_existing_device_with_asset_tag(self):
+        """_write_device_row updates an existing device and sets asset_tag."""
+        from dcim.models import Device, DeviceType, DeviceRole, Rack
+
+        Device.objects.create(name="wd-dev-04", site=self.site, device_type=self.dt, role=self.role)
+        row = self._base_row(4, device_name="wd-dev-04")
+        result = _write_device_row(
+            row,
+            self.profile,
+            self.site,
+            None,
+            None,
+            {},
+            "WD Corp",
+            "WD Model",
+            self.crm,
+            "wd-corp",
+            "wd-model",
+            "WD004",
+            "wd-dev-04",
+            "",
+            "AT001",
+            1,
+            None,
+            None,
+            "active",
+            DeviceType,
+            DeviceRole,
+            Rack,
+            Device,
+        )
+        self.assertEqual(result.action, "update")
+        dev = Device.objects.get(site=self.site, name="wd-dev-04")
+        self.assertEqual(dev.asset_tag, "AT001")
+
+    def test_skip_existing_device_when_update_existing_false(self):
+        """_write_device_row returns action='skip' when update_existing=False and device exists."""
+        from dcim.models import Device, DeviceType, DeviceRole, Rack
+
+        self.profile.update_existing = False
+        self.profile.save()
+        Device.objects.create(name="wd-dev-05", site=self.site, device_type=self.dt, role=self.role)
+        row = self._base_row(5, device_name="wd-dev-05")
+        result = _write_device_row(
+            row,
+            self.profile,
+            self.site,
+            None,
+            None,
+            {},
+            "WD Corp",
+            "WD Model",
+            self.crm,
+            "wd-corp",
+            "wd-model",
+            "WD005",
+            "wd-dev-05",
+            "",
+            None,
+            1,
+            None,
+            None,
+            "active",
+            DeviceType,
+            DeviceRole,
+            Rack,
+            Device,
+        )
+        self.assertEqual(result.action, "skip")
+        self.assertIn("update_existing=False", result.detail)
+
+
+# ---------------------------------------------------------------------------
+# New tests: Pass3EdgeCasesTest
+# ---------------------------------------------------------------------------
+
+
+class Pass3EdgeCasesTest(TestCase):
+    """Integration tests for pass-3 edge cases exercised via run_import."""
+
+    def setUp(self):
+        """Create a site and full profile for pass-3 integration tests."""
+        from dcim.models import Site
+
+        self.site = Site.objects.create(name="P3Site", slug="p3-site")
+        self.profile = _make_profile("P3Test")
+
+    def _device_row(self, **overrides):
+        """Return a synthetic device row dict with sensible defaults."""
+        base = {
+            "_row_number": 1,
+            "source_id": "P3001",
+            "device_name": "p3-dev-01",
+            "device_class": "Server",
+            "make": "Dell",
+            "model": "PowerEdge R640",
+            "u_height": "1",
+            "rack_name": "",
+            "u_position": "1",
+            "serial": "",
+            "asset_tag": "",
+            "status": "active",
+        }
+        base.update(overrides)
+        return base
+
+    def test_position_less_than_1_produces_skip(self):
+        """A row with u_position < 1 results in action='skip' for the device row."""
+        rows = [self._device_row(u_position="-1", source_id="P3001")]
+        result = run_import(rows, self.profile, {"site": self.site}, dry_run=True)
+        skip_rows = [r for r in result.rows if r.action == "skip" and r.object_type == "device"]
+        self.assertGreater(len(skip_rows), 0)
+        self.assertIn("position", skip_rows[0].detail.lower())
+
+    def test_missing_device_name_produces_error(self):
+        """A row with empty device_name results in action='error'."""
+        rows = [self._device_row(device_name="", source_id="P3002")]
+        result = run_import(rows, self.profile, {"site": self.site}, dry_run=True)
+        error_rows = [r for r in result.rows if r.action == "error" and "Missing device name" in r.detail]
+        self.assertGreater(len(error_rows), 0)
+
+    def test_unmapped_device_class_produces_error(self):
+        """A row with a device_class that has no ClassRoleMapping results in action='error'."""
+        rows = [self._device_row(device_class="UnknownClass", source_id="P3003")]
+        result = run_import(rows, self.profile, {"site": self.site}, dry_run=True)
+        error_rows = [r for r in result.rows if r.action == "error" and "No class\u2192role mapping" in r.detail]
+        self.assertGreater(len(error_rows), 0)
+
+    def test_crm_ignore_true_produces_ignore(self):
+        """A row whose ClassRoleMapping has ignore=True results in action='ignore'."""
+        ClassRoleMapping.objects.create(profile=self.profile, source_class="Ignored", ignore=True)
+        rows = [self._device_row(device_class="Ignored", source_id="P3004")]
+        result = run_import(rows, self.profile, {"site": self.site}, dry_run=True)
+        ignore_rows = [r for r in result.rows if r.action == "ignore"]
+        self.assertGreater(len(ignore_rows), 0)
+
+    def test_preview_matched_device_update_when_update_existing_true(self):
+        """In dry-run, a device matched by name with update_existing=True yields action='update'."""
+        from dcim.models import Device, Manufacturer, DeviceType, DeviceRole
+
+        mfg = Manufacturer.objects.create(name="P3 Corp", slug="p3-corp")
+        dt = DeviceType.objects.create(manufacturer=mfg, model="P3 Model", slug="p3-model")
+        role = DeviceRole.objects.create(name="P3 Role", slug="server")
+        Device.objects.create(name="p3-existing", site=self.site, device_type=dt, role=role)
+        self.profile.update_existing = True
+        self.profile.save()
+        rows = [self._device_row(device_name="p3-existing", source_id="P3005")]
+        result = run_import(rows, self.profile, {"site": self.site}, dry_run=True)
+        update_rows = [r for r in result.rows if r.action == "update" and r.object_type == "device"]
+        self.assertGreater(len(update_rows), 0)
+
+    def test_preview_matched_device_skip_when_update_existing_false(self):
+        """In dry-run, a device matched by name with update_existing=False yields action='skip'."""
+        from dcim.models import Device, Manufacturer, DeviceType, DeviceRole
+
+        mfg = Manufacturer.objects.create(name="P3B Corp", slug="p3b-corp")
+        dt = DeviceType.objects.create(manufacturer=mfg, model="P3B Model", slug="p3b-model")
+        role = DeviceRole.objects.create(name="P3B Role", slug="server-p3b")
+        Device.objects.create(name="p3b-existing", site=self.site, device_type=dt, role=role)
+        self.profile.update_existing = False
+        self.profile.save()
+        rows = [self._device_row(device_name="p3b-existing", source_id="P3006")]
+        result = run_import(rows, self.profile, {"site": self.site}, dry_run=True)
+        skip_rows = [r for r in result.rows if r.action == "skip" and r.object_type == "device"]
+        self.assertGreater(len(skip_rows), 0)
+
+
+# ---------------------------------------------------------------------------
+# New tests: Pass1UnmappedClassTest
+# ---------------------------------------------------------------------------
+
+
+class Pass1UnmappedClassTest(TestCase):
+    """Verify that rows with unmapped device_class are skipped in pass 1 (no manufacturer created)."""
+
+    def setUp(self):
+        """Create site and full profile for pass-1 tests."""
+        from dcim.models import Site
+
+        self.site = Site.objects.create(name="P1Site", slug="p1-site")
+        self.profile = _make_profile("P1Test")
+
+    def test_unmapped_class_does_not_create_manufacturer(self):
+        """A row whose device_class has no ClassRoleMapping does not trigger manufacturer creation."""
+        from dcim.models import Manufacturer
+
+        rows = [
+            {
+                "_row_number": 1,
+                "source_id": "P1001",
+                "device_name": "p1-dev-01",
+                "device_class": "UnmappedClassP1",  # no ClassRoleMapping for this class
+                "make": "UniqueMfgP1",
+                "model": "UniqueModelP1",
+                "u_height": "1",
+                "rack_name": "",
+                "u_position": "1",
+                "serial": "",
+                "asset_tag": "",
+                "status": "active",
+            }
+        ]
+        before = Manufacturer.objects.count()
+        run_import(rows, self.profile, {"site": self.site}, dry_run=True)
+        self.assertEqual(Manufacturer.objects.count(), before)

--- a/netbox_data_import/tests/test_views.py
+++ b/netbox_data_import/tests/test_views.py
@@ -1460,3 +1460,674 @@ column_transform_rules:
         profile = ImportProfile.objects.filter(name="TransformImportProfile").first()
         self.assertIsNotNone(profile)
         self.assertTrue(ColumnTransformRule.objects.filter(profile=profile, source_column="Name").exists())
+
+
+# ---------------------------------------------------------------------------
+# Additional coverage tests
+# ---------------------------------------------------------------------------
+
+
+class ColumnMappingInvalidPostTest(BaseViewTestCase):
+    """Test ColumnMappingAddView with invalid form data (covers error path)."""
+
+    def setUp(self):
+        """Set up profile."""
+        super().setUp()
+        self.profile = _make_profile("CMInvalidProfile")
+
+    def test_post_invalid_form_rerenders(self):
+        """POST with invalid data (missing source_column) re-renders the form."""
+        url = reverse("plugins:netbox_data_import:columnmapping_add", kwargs={"profile_pk": self.profile.pk})
+        resp = self.client.post(url, {"profile": self.profile.pk, "target_field": "device_name"})
+        self.assertEqual(resp.status_code, 200)
+
+    def test_edit_post_invalid_rerenders(self):
+        """Edit POST with invalid data re-renders the form."""
+        mapping = ColumnMapping.objects.create(profile=self.profile, source_column="ColXInvalid", target_field="tenant")
+        url = reverse("plugins:netbox_data_import:columnmapping_edit", kwargs={"pk": mapping.pk})
+        resp = self.client.post(url, {"profile": self.profile.pk, "target_field": ""})
+        self.assertEqual(resp.status_code, 200)
+
+    def test_delete_get_renders_confirmation(self):
+        """GET delete shows confirmation page."""
+        mapping = ColumnMapping.objects.create(profile=self.profile, source_column="ColYDelete", target_field="tenant")
+        url = reverse("plugins:netbox_data_import:columnmapping_delete", kwargs={"pk": mapping.pk})
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+
+
+class ColumnTransformRuleCRUDTest(BaseViewTestCase):
+    """Coverage tests for ColumnTransformRule add/edit/delete views."""
+
+    def setUp(self):
+        """Set up profile."""
+        super().setUp()
+        from netbox_data_import.models import ColumnTransformRule
+
+        self.ColumnTransformRule = ColumnTransformRule
+        self.profile = _make_profile("CTRCRUDProfile")
+
+    def test_get_add_view(self):
+        """GET column-transform-rule-add returns 200."""
+        url = reverse("plugins:netbox_data_import:columntransformrule_add", kwargs={"profile_pk": self.profile.pk})
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+
+    def test_post_add_creates_rule(self):
+        """POST valid data creates a new ColumnTransformRule."""
+        url = reverse("plugins:netbox_data_import:columntransformrule_add", kwargs={"profile_pk": self.profile.pk})
+        resp = self.client.post(
+            url,
+            {
+                "profile": self.profile.pk,
+                "source_column": "CTRColZNew",
+                "pattern": r"^(.+)$",
+                "group_1_target": "device_name",
+                "group_2_target": "",
+            },
+        )
+        self.assertIn(resp.status_code, [200, 302])
+        self.assertTrue(
+            self.ColumnTransformRule.objects.filter(profile=self.profile, source_column="CTRColZNew").exists()
+        )
+
+    def test_post_add_invalid_rerenders(self):
+        """POST with missing data re-renders with 200."""
+        url = reverse("plugins:netbox_data_import:columntransformrule_add", kwargs={"profile_pk": self.profile.pk})
+        resp = self.client.post(url, {"profile": self.profile.pk})
+        self.assertEqual(resp.status_code, 200)
+
+    def test_get_edit_view(self):
+        """GET edit view returns 200."""
+        rule = self.ColumnTransformRule.objects.create(
+            profile=self.profile,
+            source_column="EditColCTR",
+            pattern=r"^(.+)$",
+            group_1_target="device_name",
+            group_2_target="",
+        )
+        url = reverse("plugins:netbox_data_import:columntransformrule_edit", kwargs={"pk": rule.pk})
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+
+    def test_post_edit_updates_rule(self):
+        """POST edit with valid data saves the rule."""
+        rule = self.ColumnTransformRule.objects.create(
+            profile=self.profile,
+            source_column="EditColCTR2",
+            pattern=r"^(.+)$",
+            group_1_target="device_name",
+            group_2_target="",
+        )
+        url = reverse("plugins:netbox_data_import:columntransformrule_edit", kwargs={"pk": rule.pk})
+        resp = self.client.post(
+            url,
+            {
+                "profile": self.profile.pk,
+                "source_column": "EditColCTR2",
+                "pattern": r"^(\w+)$",
+                "group_1_target": "asset_tag",
+                "group_2_target": "",
+            },
+        )
+        self.assertIn(resp.status_code, [200, 302])
+
+    def test_post_edit_invalid_rerenders(self):
+        """POST edit with invalid data re-renders with 200."""
+        rule = self.ColumnTransformRule.objects.create(
+            profile=self.profile,
+            source_column="EditColCTR3",
+            pattern=r"^(.+)$",
+            group_1_target="device_name",
+            group_2_target="",
+        )
+        url = reverse("plugins:netbox_data_import:columntransformrule_edit", kwargs={"pk": rule.pk})
+        resp = self.client.post(url, {"profile": self.profile.pk})
+        self.assertEqual(resp.status_code, 200)
+
+    def test_get_delete_view(self):
+        """GET delete view returns 200."""
+        rule = self.ColumnTransformRule.objects.create(
+            profile=self.profile,
+            source_column="DelColCTR",
+            pattern=r"^(.+)$",
+            group_1_target="device_name",
+            group_2_target="",
+        )
+        url = reverse("plugins:netbox_data_import:columntransformrule_delete", kwargs={"pk": rule.pk})
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+
+    def test_post_delete_removes_rule(self):
+        """POST delete removes the rule."""
+        rule = self.ColumnTransformRule.objects.create(
+            profile=self.profile,
+            source_column="DelColCTR2",
+            pattern=r"^(.+)$",
+            group_1_target="device_name",
+            group_2_target="",
+        )
+        url = reverse("plugins:netbox_data_import:columntransformrule_delete", kwargs={"pk": rule.pk})
+        resp = self.client.post(url, {})
+        self.assertIn(resp.status_code, [200, 302])
+        self.assertFalse(self.ColumnTransformRule.objects.filter(pk=rule.pk).exists())
+
+
+class CheckDeviceNameEdgeCasesTest(BaseViewTestCase):
+    """Cover CheckDeviceNameView empty-name path."""
+
+    def test_check_empty_name_returns_false(self):
+        """GET with empty name returns exists=False."""
+        import json
+
+        url = reverse("plugins:netbox_data_import:check_device")
+        resp = self.client.get(url + "?name=")
+        self.assertEqual(resp.status_code, 200)
+        data = json.loads(resp.content)
+        self.assertFalse(data["exists"])
+
+
+class ModelsStrTest(BaseViewTestCase):
+    """Coverage tests for __str__ and get_absolute_url on model classes."""
+
+    def setUp(self):
+        """Create model instances for __str__ tests."""
+        super().setUp()
+        self.profile = _make_profile("StrTestProfile")
+
+    def test_column_mapping_str(self):
+        """ColumnMapping.__str__ returns 'source -> target' string."""
+        m = ColumnMapping.objects.get(profile=self.profile, source_column="Id")
+        self.assertIn("→", str(m))
+
+    def test_column_mapping_absolute_url(self):
+        """ColumnMapping.get_absolute_url returns a valid URL."""
+        m = ColumnMapping.objects.get(profile=self.profile, source_column="Id")
+        url = m.get_absolute_url()
+        self.assertIn(str(m.pk), url)
+
+    def test_class_role_mapping_str_rack(self):
+        """ClassRoleMapping.__str__ for creates_rack=True shows 'Rack'."""
+        crm = self.profile.class_role_mappings.get(source_class="Cabinet")
+        self.assertIn("Rack", str(crm))
+
+    def test_class_role_mapping_str_role(self):
+        """ClassRoleMapping.__str__ for device role shows role_slug."""
+        crm = self.profile.class_role_mappings.get(source_class="Server")
+        self.assertIn("server", str(crm))
+
+    def test_class_role_mapping_absolute_url(self):
+        """ClassRoleMapping.get_absolute_url returns a valid URL."""
+        crm = self.profile.class_role_mappings.get(source_class="Cabinet")
+        url = crm.get_absolute_url()
+        self.assertIn(str(crm.pk), url)
+
+    def test_device_type_mapping_str(self):
+        """DeviceTypeMapping.__str__ returns make/model -> mfg/dt string."""
+        dtm = DeviceTypeMapping.objects.create(
+            profile=self.profile,
+            source_make="AristaStr",
+            source_model="7050X",
+            netbox_manufacturer_slug="arista-str",
+            netbox_device_type_slug="arista-7050x",
+        )
+        self.assertIn("AristaStr", str(dtm))
+        self.assertIn("arista-7050x", str(dtm))
+
+    def test_device_type_mapping_absolute_url(self):
+        """DeviceTypeMapping.get_absolute_url returns a valid URL."""
+        dtm = DeviceTypeMapping.objects.create(
+            profile=self.profile,
+            source_make="AristaStr2",
+            source_model="7050X2",
+            netbox_manufacturer_slug="arista-str2",
+            netbox_device_type_slug="arista-7050x2",
+        )
+        self.assertIn(str(dtm.pk), dtm.get_absolute_url())
+
+    def test_manufacturer_mapping_str(self):
+        """ManufacturerMapping.__str__ shows source_make -> netbox_slug."""
+        mm = ManufacturerMapping.objects.create(
+            profile=self.profile, source_make="Dell EMC Str", netbox_manufacturer_slug="dell-str"
+        )
+        s = str(mm)
+        self.assertIn("Dell EMC Str", s)
+        self.assertIn("dell-str", s)
+
+    def test_import_job_str(self):
+        """ImportJob.__str__ contains the pk."""
+        from netbox_data_import.models import ImportJob
+
+        job = ImportJob.objects.create(profile=self.profile, dry_run=True, input_filename="test.xlsx")
+        s = str(job)
+        self.assertIn(str(job.pk), s)
+
+    def test_import_job_absolute_url(self):
+        """ImportJob.get_absolute_url returns the associated profile's URL."""
+        from netbox_data_import.models import ImportJob
+
+        job = ImportJob.objects.create(profile=self.profile, dry_run=True)
+        url = job.get_absolute_url()
+        self.assertIn(str(self.profile.pk), url)
+
+    def test_ignored_device_str(self):
+        """IgnoredDevice.__str__ includes device_name."""
+        from netbox_data_import.models import IgnoredDevice
+
+        ig = IgnoredDevice.objects.create(profile=self.profile, source_id="STR-IGN-UNIQUE", device_name="test-dev-str")
+        self.assertIn("test-dev-str", str(ig))
+        self.assertIn("ignored", str(ig))
+
+    def test_column_transform_rule_str(self):
+        """ColumnTransformRule.__str__ shows column and pattern."""
+        from netbox_data_import.models import ColumnTransformRule
+
+        rule = ColumnTransformRule.objects.create(
+            profile=self.profile,
+            source_column="StrColUniq",
+            pattern=r"^(.+)$",
+            group_1_target="device_name",
+            group_2_target="",
+        )
+        s = str(rule)
+        self.assertIn("StrColUniq", s)
+
+    def test_column_transform_rule_absolute_url(self):
+        """ColumnTransformRule.get_absolute_url returns a valid URL."""
+        from netbox_data_import.models import ColumnTransformRule
+
+        rule = ColumnTransformRule.objects.create(
+            profile=self.profile,
+            source_column="UrlColUniq",
+            pattern=r"^(.+)$",
+            group_1_target="device_name",
+            group_2_target="",
+        )
+        self.assertIn(str(rule.pk), rule.get_absolute_url())
+
+    def test_source_resolution_str(self):
+        """SourceResolution.__str__ includes source_id and column."""
+        res = SourceResolution.objects.create(
+            profile=self.profile,
+            source_id="STR-SRC-UNIQ",
+            source_column="Name",
+            original_value="old",
+            resolved_fields={},
+        )
+        s = str(res)
+        self.assertIn("STR-SRC-UNIQ", s)
+        self.assertIn("Name", s)
+
+    def test_device_existing_match_str(self):
+        """DeviceExistingMatch.__str__ includes source_id."""
+        from netbox_data_import.models import DeviceExistingMatch
+
+        dem = DeviceExistingMatch.objects.create(
+            profile=self.profile, source_id="DEM-UNIQ-001", netbox_device_id=1, device_name="dev-x"
+        )
+        s = str(dem)
+        self.assertIn("DEM-UNIQ-001", s)
+
+
+class SafeNextUrlTest(BaseViewTestCase):
+    """Tests for _safe_next_url helper."""
+
+    def test_safe_url_fallback_for_external(self):
+        """_safe_next_url falls back when next is an external URL."""
+        from netbox_data_import.views import _safe_next_url
+        from django.test import RequestFactory
+
+        factory = RequestFactory()
+        req = factory.post("/", {"next": "http://evil.example.com/phish"})
+        result = _safe_next_url(req, "plugins:netbox_data_import:importprofile_list")
+        self.assertNotIn("evil.example.com", result)
+
+    def test_safe_url_fallback_for_empty(self):
+        """_safe_next_url returns fallback when next is empty."""
+        from netbox_data_import.views import _safe_next_url
+        from django.test import RequestFactory
+
+        factory = RequestFactory()
+        req = factory.post("/", {})
+        result = _safe_next_url(req, "plugins:netbox_data_import:importprofile_list")
+        self.assertIn("import", result)
+
+
+class BulkYamlImportExtendedTest(BaseViewTestCase):
+    """Test BulkYamlImportView with class_role mapping type and error cases."""
+
+    def setUp(self):
+        """Set up profile."""
+        super().setUp()
+        self.profile = _make_profile("BulkYamlCRMProfileX")
+
+    def test_no_yaml_file_shows_error(self):
+        """POST without file returns 200 with error."""
+        url = reverse("plugins:netbox_data_import:bulk_yaml_import", kwargs={"profile_pk": self.profile.pk})
+        resp = self.client.post(url, {"mapping_type": "class_role"})
+        self.assertEqual(resp.status_code, 200)
+
+    def test_invalid_yaml_shows_error(self):
+        """POST with unparseable YAML shows error."""
+        url = reverse("plugins:netbox_data_import:bulk_yaml_import", kwargs={"profile_pk": self.profile.pk})
+        bad = BytesIO(b": {{{ invalid")
+        bad.name = "bad.yaml"
+        resp = self.client.post(url, {"mapping_type": "class_role", "yaml_file": bad})
+        self.assertEqual(resp.status_code, 200)
+
+    def test_non_list_yaml_shows_error(self):
+        """POST with YAML dict (not list) shows error."""
+        url = reverse("plugins:netbox_data_import:bulk_yaml_import", kwargs={"profile_pk": self.profile.pk})
+        f = BytesIO(b"key: value")
+        f.name = "notalist.yaml"
+        resp = self.client.post(url, {"mapping_type": "class_role", "yaml_file": f})
+        self.assertEqual(resp.status_code, 200)
+
+    def test_class_role_yaml_creates_mapping(self):
+        """POST with valid class_role YAML creates ClassRoleMapping."""
+        url = reverse("plugins:netbox_data_import:bulk_yaml_import", kwargs={"profile_pk": self.profile.pk})
+        yaml_content = b"""
+- source_class: StorageArrayX
+  creates_rack: false
+  role_slug: storage
+  ignore: false
+"""
+        f = BytesIO(yaml_content)
+        f.name = "cr.yaml"
+        resp = self.client.post(url, {"mapping_type": "class_role", "yaml_file": f})
+        self.assertIn(resp.status_code, [200, 302])
+        self.assertTrue(ClassRoleMapping.objects.filter(profile=self.profile, source_class="StorageArrayX").exists())
+
+
+class SourceResolutionDeleteViewTest(BaseViewTestCase):
+    """Tests for SourceResolutionDeleteView GET."""
+
+    def setUp(self):
+        """Set up a resolution to delete."""
+        super().setUp()
+        self.profile = _make_profile("DelResProfileX")
+        self.res = SourceResolution.objects.create(
+            profile=self.profile,
+            source_id="DELRES-UNIQ-001",
+            source_column="Name",
+            original_value="old-val",
+            resolved_fields={},
+        )
+
+    def test_get_delete_page_returns_200(self):
+        """GET delete confirmation page returns 200."""
+        url = reverse("plugins:netbox_data_import:source_resolution_delete", kwargs={"pk": self.res.pk})
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+
+    def test_post_delete_removes_resolution(self):
+        """POST delete removes the resolution."""
+        url = reverse("plugins:netbox_data_import:source_resolution_delete", kwargs={"pk": self.res.pk})
+        resp = self.client.post(url)
+        self.assertIn(resp.status_code, [200, 302])
+        if resp.status_code == 302:
+            self.assertFalse(SourceResolution.objects.filter(pk=self.res.pk).exists())
+
+
+class ClassRoleMappingInvalidPostTest(BaseViewTestCase):
+    """Cover ClassRoleMappingAddView and EditView invalid POST paths."""
+
+    def setUp(self):
+        """Set up profile and a mapping."""
+        super().setUp()
+        self.profile = _make_profile("CRMInvalidProfile")
+        self.crm = ClassRoleMapping.objects.create(
+            profile=self.profile, source_class="CRMTestClass", creates_rack=False, role_slug="crm-role"
+        )
+
+    def test_add_invalid_rerenders(self):
+        """POST with missing source_class re-renders ClassRoleMappingAddView."""
+        url = reverse("plugins:netbox_data_import:classrolemapping_add", kwargs={"profile_pk": self.profile.pk})
+        resp = self.client.post(url, {"profile": self.profile.pk, "creates_rack": "false"})
+        self.assertEqual(resp.status_code, 200)
+
+    def test_edit_invalid_rerenders(self):
+        """POST with missing source_class re-renders ClassRoleMappingEditView."""
+        url = reverse("plugins:netbox_data_import:classrolemapping_edit", kwargs={"pk": self.crm.pk})
+        resp = self.client.post(url, {"profile": self.profile.pk})
+        self.assertEqual(resp.status_code, 200)
+
+
+class DeviceTypeMappingInvalidPostTest(BaseViewTestCase):
+    """Cover DeviceTypeMappingAddView and EditView invalid POST paths."""
+
+    def setUp(self):
+        """Set up profile and a mapping."""
+        super().setUp()
+        self.profile = _make_profile("DTMInvalidProfile")
+        self.dtm = DeviceTypeMapping.objects.create(
+            profile=self.profile,
+            source_make="DTMInvalidMake",
+            source_model="DTMInvalidModel",
+            netbox_manufacturer_slug="dtm-mfg",
+            netbox_device_type_slug="dtm-dt",
+        )
+
+    def test_add_invalid_rerenders(self):
+        """POST with missing required fields re-renders DeviceTypeMappingAddView."""
+        url = reverse("plugins:netbox_data_import:devicetypemapping_add", kwargs={"profile_pk": self.profile.pk})
+        resp = self.client.post(url, {"profile": self.profile.pk})
+        self.assertEqual(resp.status_code, 200)
+
+    def test_edit_invalid_rerenders(self):
+        """POST with missing required fields re-renders DeviceTypeMappingEditView."""
+        url = reverse("plugins:netbox_data_import:devicetypemapping_edit", kwargs={"pk": self.dtm.pk})
+        resp = self.client.post(url, {"profile": self.profile.pk})
+        self.assertEqual(resp.status_code, 200)
+
+
+class CheckDeviceMultipleResultsTest(BaseViewTestCase):
+    """Cover CheckDeviceNameView MultipleObjectsReturned path (lines 1025-1028)."""
+
+    def setUp(self):
+        """Create two devices with identical names (different sites)."""
+        super().setUp()
+        from dcim.models import Site, Manufacturer, DeviceType, DeviceRole, Device
+
+        site1 = Site.objects.create(name="MDSite1", slug="md-site-1")
+        site2 = Site.objects.create(name="MDSite2", slug="md-site-2")
+        mfg = Manufacturer.objects.create(name="MDMfg", slug="md-mfg")
+        dt = DeviceType.objects.create(manufacturer=mfg, model="MDModel", slug="md-model")
+        role = DeviceRole.objects.create(name="MDRole", slug="md-role")
+        Device.objects.create(name="md-shared-name", device_type=dt, role=role, site=site1)
+        Device.objects.create(name="md-shared-name", device_type=dt, role=role, site=site2)
+
+    def test_multiple_devices_same_name_returns_exists_true(self):
+        """GET with a name matching multiple devices returns exists=True with count>1."""
+        import json
+
+        url = reverse("plugins:netbox_data_import:check_device")
+        resp = self.client.get(url + "?name=md-shared-name")
+        self.assertEqual(resp.status_code, 200)
+        data = json.loads(resp.content)
+        self.assertTrue(data["exists"])
+        self.assertGreater(data.get("count", 1), 1)
+
+
+class QuickResolveDeviceTypeMissingFieldsTest(BaseViewTestCase):
+    """Cover QuickResolveDeviceTypeView missing make/model and auto-slugify paths."""
+
+    def setUp(self):
+        """Set up profile."""
+        super().setUp()
+        self.profile = _make_profile("QRDTMissingProfile")
+
+    def test_missing_source_make_redirects(self):
+        """POST without source_make shows error and redirects."""
+        url = reverse("plugins:netbox_data_import:quick_resolve_device_type")
+        resp = self.client.post(
+            url,
+            {
+                "profile_id": self.profile.pk,
+                "source_make": "",
+                "source_model": "SomeModel",
+                "netbox_mfg_slug": "",
+                "netbox_dt_slug": "",
+                "action": "map",
+            },
+        )
+        self.assertEqual(resp.status_code, 302)
+
+    def test_auto_slugify_when_slugs_empty(self):
+        """POST without explicit slugs auto-slugifies from source_make/source_model."""
+        url = reverse("plugins:netbox_data_import:quick_resolve_device_type")
+        resp = self.client.post(
+            url,
+            {
+                "profile_id": self.profile.pk,
+                "source_make": "Auto Mfg",
+                "source_model": "Auto Model",
+                "netbox_mfg_slug": "",  # will be auto-slugified
+                "netbox_dt_slug": "",  # will be auto-slugified
+                "action": "map",
+            },
+        )
+        self.assertIn(resp.status_code, [200, 302])
+        self.assertTrue(
+            DeviceTypeMapping.objects.filter(
+                profile=self.profile, source_make="Auto Mfg", source_model="Auto Model"
+            ).exists()
+        )
+
+    def test_create_now_invalid_u_height_defaults_to_one(self):
+        """POST action=create_now with invalid u_height defaults to 1."""
+        from dcim.models import DeviceType
+
+        url = reverse("plugins:netbox_data_import:quick_resolve_device_type")
+        self.client.post(
+            url,
+            {
+                "profile_id": self.profile.pk,
+                "source_make": "UHMfg2",
+                "source_model": "UHModel2",
+                "netbox_mfg_slug": "uh-mfg2",
+                "netbox_dt_slug": "uh-model2",
+                "u_height": "not-a-number",
+                "action": "create_now",
+            },
+        )
+        dt = DeviceType.objects.filter(slug="uh-model2").first()
+        self.assertIsNotNone(dt)
+        self.assertEqual(dt.u_height, 1)
+
+
+class AutoMatchAmbiguousNameTest(BaseViewTestCase):
+    """Cover _auto_match_single_device ambiguous name path (line 1387)."""
+
+    def setUp(self):
+        """Set up profile and two devices with the same name (different sites)."""
+        super().setUp()
+        from dcim.models import Site, Manufacturer, DeviceType, DeviceRole, Device
+
+        self.site = Site.objects.create(name="AmbNameSite", slug="amb-name-site")
+        site2 = Site.objects.create(name="AmbNameSite2", slug="amb-name-site2")
+        mfg = Manufacturer.objects.create(name="AmbNameMfg", slug="amb-name-mfg")
+        dt = DeviceType.objects.create(manufacturer=mfg, model="AmbNameModel", slug="amb-name-model")
+        role = DeviceRole.objects.create(name="AmbNameRole", slug="amb-name-role")
+        Device.objects.create(name="ambname-shared", device_type=dt, role=role, site=self.site)
+        Device.objects.create(name="ambname-shared", device_type=dt, role=role, site=site2)
+        self.profile = _make_profile("AmbNameProfile")
+
+    def test_ambiguous_name_match_no_link(self):
+        """Rows with ambiguous name match (multiple devices) do NOT create DeviceExistingMatch."""
+        from netbox_data_import.models import DeviceExistingMatch
+
+        session = self.client.session
+        session["import_rows"] = [
+            {
+                "_row_number": 1,
+                "source_id": "AMBNAME-001",
+                "device_name": "ambname-shared",
+                "serial": "",
+                "asset_tag": "",
+            }
+        ]
+        session.save()
+        url = reverse("plugins:netbox_data_import:auto_match_devices")
+        resp = self.client.post(url, {"profile_id": self.profile.pk})
+        self.assertEqual(resp.status_code, 302)
+        self.assertFalse(DeviceExistingMatch.objects.filter(profile=self.profile, source_id="AMBNAME-001").exists())
+
+
+class SerializeRowsTest(BaseViewTestCase):
+    """Cover _serialize_rows datetime handling (line 1470)."""
+
+    def test_serialize_rows_with_datetime(self):
+        """_serialize_rows converts datetime values to ISO format strings."""
+        import datetime
+        from netbox_data_import.views import _serialize_rows
+
+        rows = [{"_row_number": 1, "device_name": "test", "created_at": datetime.datetime(2025, 1, 1, 12, 0, 0)}]
+        result = _serialize_rows(rows)
+        self.assertEqual(result[0]["created_at"], "2025-01-01T12:00:00")
+
+    def test_serialize_rows_with_date(self):
+        """_serialize_rows converts date values to ISO format strings."""
+        import datetime
+        from netbox_data_import.views import _serialize_rows
+
+        rows = [{"_row_number": 1, "created_at": datetime.date(2025, 6, 1)}]
+        result = _serialize_rows(rows)
+        self.assertEqual(result[0]["created_at"], "2025-06-01")
+
+
+class SaveResolutionJsonErrorTest(BaseViewTestCase):
+    """Test SaveResolutionView with malformed JSON (lines 642-643)."""
+
+    def setUp(self):
+        """Set up profile."""
+        super().setUp()
+        self.profile = _make_profile("SaveResJsonProfile")
+
+    def test_malformed_json_defaults_to_empty_dict(self):
+        """POST with malformed resolved_fields JSON silently defaults to empty dict."""
+        url = reverse("plugins:netbox_data_import:save_resolution")
+        resp = self.client.post(
+            url,
+            {
+                "profile_id": self.profile.pk,
+                "source_id": "JSONERR-001",
+                "source_column": "Name",
+                "original_value": "old",
+                "resolved_fields": "THIS IS NOT JSON {{{{",
+            },
+        )
+        self.assertIn(resp.status_code, [200, 302])
+        # Resolution should still be saved (with empty resolved_fields)
+        from netbox_data_import.models import SourceResolution
+
+        res = SourceResolution.objects.filter(profile=self.profile, source_id="JSONERR-001").first()
+        self.assertIsNotNone(res)
+        self.assertEqual(res.resolved_fields, {})
+
+
+class AutoMatchAmbiguousAssetTagTest(BaseViewTestCase):
+    """Cover _auto_match_single_device ambiguous asset_tag path (lines 1379-1380)."""
+
+    def setUp(self):
+        """Set up profile."""
+        super().setUp()
+        self.profile = _make_profile("AmbATProfile")
+
+    def test_ambiguous_asset_tag_returns_none_is_ambiguous(self):
+        """_auto_match_single_device returns (None, True) when asset_tag matches multiple devices."""
+        from unittest.mock import MagicMock
+        from netbox_data_import.views import _auto_match_single_device
+
+        mock_dev_model = MagicMock()
+        # Return 2 results for asset_tag filter (ambiguous)
+        mock_dev_model.objects.filter.return_value.__getitem__ = lambda self, s: [MagicMock(), MagicMock()]
+
+        # Use a sliceable mock: filter(...)[:2] returns list of 2
+        qs_mock = MagicMock()
+        qs_mock.__getitem__ = MagicMock(return_value=[MagicMock(), MagicMock()])
+        mock_dev_model.objects.filter.return_value = qs_mock
+
+        device, is_ambiguous = _auto_match_single_device(mock_dev_model, "any-name", "", "SHARED-TAG")
+        self.assertIsNone(device)
+        self.assertTrue(is_ambiguous)

--- a/netbox_data_import/tests/test_views.py
+++ b/netbox_data_import/tests/test_views.py
@@ -1221,6 +1221,171 @@ class AutoMatchDevicesViewTest(BaseViewTestCase):
         resp = self.client.post(url, {"profile_id": self.profile.pk})
         self.assertEqual(resp.status_code, 302)
 
+    def test_post_automatch_by_asset_tag(self):
+        """POST with a row matching only by asset_tag creates a DeviceExistingMatch."""
+        from dcim.models import Manufacturer, DeviceType, DeviceRole, Device
+        from netbox_data_import.models import DeviceExistingMatch
+
+        mfg = Manufacturer.objects.create(name="TagMfg", slug="tag-mfg")
+        dt = DeviceType.objects.create(manufacturer=mfg, model="TagModel", slug="tag-model")
+        role = DeviceRole.objects.create(name="TagRole", slug="tag-role")
+        device = Device.objects.create(
+            name="tag-device-01", asset_tag="ASSET-TAG-01", device_type=dt, role=role, site=self.site
+        )
+
+        session = self.client.session
+        session["import_rows"] = [
+            {
+                "_row_number": 1,
+                "source_id": "TAG-001",
+                "device_name": "tag-device-01",
+                "serial": "",
+                "asset_tag": "ASSET-TAG-01",
+            }
+        ]
+        session.save()
+
+        url = reverse("plugins:netbox_data_import:auto_match_devices")
+        resp = self.client.post(url, {"profile_id": self.profile.pk})
+        self.assertEqual(resp.status_code, 302)
+        self.assertTrue(
+            DeviceExistingMatch.objects.filter(
+                profile=self.profile, source_id="TAG-001", netbox_device_id=device.pk
+            ).exists()
+        )
+
+    def test_post_automatch_by_exact_name(self):
+        """POST with a row matching only by exact device name creates a DeviceExistingMatch."""
+        from dcim.models import Manufacturer, DeviceType, DeviceRole, Device
+        from netbox_data_import.models import DeviceExistingMatch
+
+        mfg = Manufacturer.objects.create(name="NameMfg", slug="name-mfg")
+        dt = DeviceType.objects.create(manufacturer=mfg, model="NameModel", slug="name-model")
+        role = DeviceRole.objects.create(name="NameRole", slug="name-role")
+        device = Device.objects.create(name="name-device-01", device_type=dt, role=role, site=self.site)
+
+        session = self.client.session
+        session["import_rows"] = [
+            {"_row_number": 1, "source_id": "NAME-001", "device_name": "name-device-01", "serial": "", "asset_tag": ""}
+        ]
+        session.save()
+
+        url = reverse("plugins:netbox_data_import:auto_match_devices")
+        resp = self.client.post(url, {"profile_id": self.profile.pk})
+        self.assertEqual(resp.status_code, 302)
+        self.assertTrue(
+            DeviceExistingMatch.objects.filter(
+                profile=self.profile, source_id="NAME-001", netbox_device_id=device.pk
+            ).exists()
+        )
+
+    def test_post_automatch_ambiguous_serial_skips(self):
+        """POST with ambiguous serial (multiple devices) does NOT create a match."""
+        from dcim.models import Manufacturer, DeviceType, DeviceRole, Device
+        from netbox_data_import.models import DeviceExistingMatch
+
+        mfg = Manufacturer.objects.create(name="AmbMfg", slug="amb-mfg")
+        dt = DeviceType.objects.create(manufacturer=mfg, model="AmbModel", slug="amb-model")
+        role = DeviceRole.objects.create(name="AmbRole", slug="amb-role")
+        # Two devices sharing a serial (unusual but tested for robustness)
+        Device.objects.create(name="amb-device-01", serial="AMBSERIAL-01", device_type=dt, role=role, site=self.site)
+        Device.objects.create(name="amb-device-02", serial="AMBSERIAL-01", device_type=dt, role=role, site=self.site)
+
+        session = self.client.session
+        session["import_rows"] = [
+            {
+                "_row_number": 1,
+                "source_id": "AMB-001",
+                "device_name": "amb-device-01",
+                "serial": "AMBSERIAL-01",
+                "asset_tag": "",
+            }
+        ]
+        session.save()
+
+        url = reverse("plugins:netbox_data_import:auto_match_devices")
+        resp = self.client.post(url, {"profile_id": self.profile.pk})
+        self.assertEqual(resp.status_code, 302)
+        self.assertFalse(DeviceExistingMatch.objects.filter(profile=self.profile, source_id="AMB-001").exists())
+
+    def test_post_automatch_already_matched_skips(self):
+        """POST with a row that already has a DeviceExistingMatch increments 'already' counter but does not create a duplicate."""
+        from netbox_data_import.models import DeviceExistingMatch
+
+        DeviceExistingMatch.objects.create(
+            profile=self.profile,
+            source_id="ALREADY-001",
+            netbox_device_id=self.device.pk,
+            device_name=self.device.name,
+        )
+
+        session = self.client.session
+        session["import_rows"] = [
+            {
+                "_row_number": 1,
+                "source_id": "ALREADY-001",
+                "device_name": "automatch-device-01",
+                "serial": "SERIAL-AM-01",
+                "asset_tag": "",
+            }
+        ]
+        session.save()
+
+        url = reverse("plugins:netbox_data_import:auto_match_devices")
+        resp = self.client.post(url, {"profile_id": self.profile.pk})
+        self.assertEqual(resp.status_code, 302)
+        # Still exactly one match
+        self.assertEqual(DeviceExistingMatch.objects.filter(profile=self.profile, source_id="ALREADY-001").count(), 1)
+
+    def test_post_automatch_no_source_id_skips(self):
+        """Rows without source_id are silently skipped."""
+        from netbox_data_import.models import DeviceExistingMatch
+
+        session = self.client.session
+        session["import_rows"] = [
+            {
+                "_row_number": 1,
+                "source_id": "",
+                "device_name": "automatch-device-01",
+                "serial": "SERIAL-AM-01",
+                "asset_tag": "",
+            }
+        ]
+        session.save()
+
+        url = reverse("plugins:netbox_data_import:auto_match_devices")
+        resp = self.client.post(url, {"profile_id": self.profile.pk})
+        self.assertEqual(resp.status_code, 302)
+        self.assertFalse(DeviceExistingMatch.objects.filter(profile=self.profile).exists())
+
+    def test_post_automatch_probable_name_match_no_link(self):
+        """POST with a name substring match does NOT create a DeviceExistingMatch (probable only)."""
+        from dcim.models import Manufacturer, DeviceType, DeviceRole, Device
+        from netbox_data_import.models import DeviceExistingMatch
+
+        mfg = Manufacturer.objects.create(name="ProbMfg", slug="prob-mfg")
+        dt = DeviceType.objects.create(manufacturer=mfg, model="ProbModel", slug="prob-model")
+        role = DeviceRole.objects.create(name="ProbRole", slug="prob-role")
+        Device.objects.create(name="probable-device", device_type=dt, role=role, site=self.site)
+
+        session = self.client.session
+        session["import_rows"] = [
+            {
+                "_row_number": 1,
+                "source_id": "PROB-001",
+                "device_name": "prefix - probable-device",
+                "serial": "",
+                "asset_tag": "",
+            }
+        ]
+        session.save()
+
+        url = reverse("plugins:netbox_data_import:auto_match_devices")
+        resp = self.client.post(url, {"profile_id": self.profile.pk})
+        self.assertEqual(resp.status_code, 302)
+        # Probable match doesn't auto-link
+        self.assertFalse(DeviceExistingMatch.objects.filter(profile=self.profile, source_id="PROB-001").exists())
+
 
 class ImportRunViewTest(BaseViewTestCase):
     """Tests for ImportRunView (executes the actual import)."""

--- a/netbox_data_import/views.py
+++ b/netbox_data_import/views.py
@@ -1347,7 +1347,7 @@ class SearchNetBoxObjectsView(LoginRequiredMixin, View):
         return JsonResponse({"results": results})
 
 
-def _auto_match_single_device(Device, profile, source_id, device_name, serial, asset_tag):
+def _auto_match_single_device(device_model, device_name, serial, asset_tag):
     """Try to match a single device row to an existing NetBox device.
 
     Returns (device_or_None, is_ambiguous).  Matching priority: serial →
@@ -1355,21 +1355,21 @@ def _auto_match_single_device(Device, profile, source_id, device_name, serial, a
     """
     device = None
     if serial:
-        results = list(Device.objects.filter(serial=serial)[:2])
+        results = list(device_model.objects.filter(serial=serial)[:2])
         if len(results) == 1:
             device = results[0]
         elif len(results) > 1:
             return None, True
 
     if device is None and asset_tag:
-        results = list(Device.objects.filter(asset_tag=asset_tag)[:2])
+        results = list(device_model.objects.filter(asset_tag=asset_tag)[:2])
         if len(results) == 1:
             device = results[0]
         elif len(results) > 1:
             return None, True
 
     if device is None and device_name:
-        results = list(Device.objects.filter(name=device_name)[:2])
+        results = list(device_model.objects.filter(name=device_name)[:2])
         if len(results) == 1:
             device = results[0]
         elif len(results) > 1:
@@ -1409,7 +1409,7 @@ class AutoMatchDevicesView(LoginRequiredMixin, View):
                 already += 1
                 continue
 
-            device, is_ambiguous = _auto_match_single_device(Device, profile, source_id, device_name, serial, asset_tag)
+            device, is_ambiguous = _auto_match_single_device(Device, device_name, serial, asset_tag)
             if is_ambiguous:
                 ambiguous += 1
                 continue

--- a/netbox_data_import/views.py
+++ b/netbox_data_import/views.py
@@ -1355,24 +1355,24 @@ def _auto_match_single_device(Device, profile, source_id, device_name, serial, a
     """
     device = None
     if serial:
-        qs = Device.objects.filter(serial=serial)
-        if qs.count() == 1:
-            device = qs.first()
-        elif qs.count() > 1:
+        results = list(Device.objects.filter(serial=serial)[:2])
+        if len(results) == 1:
+            device = results[0]
+        elif len(results) > 1:
             return None, True
 
     if device is None and asset_tag:
-        qs = Device.objects.filter(asset_tag=asset_tag)
-        if qs.count() == 1:
-            device = qs.first()
-        elif qs.count() > 1:
+        results = list(Device.objects.filter(asset_tag=asset_tag)[:2])
+        if len(results) == 1:
+            device = results[0]
+        elif len(results) > 1:
             return None, True
 
     if device is None and device_name:
-        qs = Device.objects.filter(name=device_name)
-        if qs.count() == 1:
-            device = qs.first()
-        elif qs.count() > 1:
+        results = list(Device.objects.filter(name=device_name)[:2])
+        if len(results) == 1:
+            device = results[0]
+        elif len(results) > 1:
             return None, True
 
     return device, False

--- a/netbox_data_import/views.py
+++ b/netbox_data_import/views.py
@@ -4,6 +4,7 @@ from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.views import View
 from netbox.views import generic
 from .models import (
@@ -32,6 +33,16 @@ from .tables import (
     ColumnTransformRuleTable,
 )
 from .filters import ImportProfileFilterSet
+
+
+def _safe_next_url(request, fallback: str) -> str:
+    """Return a validated same-host redirect URL from POST or the fallback view name."""
+    url = request.POST.get("next", "")
+    if url and url_has_allowed_host_and_scheme(
+        url, allowed_hosts={request.get_host()}, require_https=request.is_secure()
+    ):
+        return url
+    return reverse(fallback)
 
 
 # ---------------------------------------------------------------------------
@@ -573,7 +584,7 @@ class IgnoreDeviceView(LoginRequiredMixin, View):
         profile_id = request.POST.get("profile_id")
         source_id = request.POST.get("source_id")
         device_name = request.POST.get("device_name", "")
-        next_url = request.POST.get("next", reverse("plugins:netbox_data_import:import_preview"))
+        next_url = _safe_next_url(request, "plugins:netbox_data_import:import_preview")
 
         if profile_id and source_id:
             profile = get_object_or_404(ImportProfile, pk=profile_id)
@@ -595,7 +606,7 @@ class UnignoreDeviceView(LoginRequiredMixin, View):
 
         profile_id = request.POST.get("profile_id")
         source_id = request.POST.get("source_id")
-        next_url = request.POST.get("next", reverse("plugins:netbox_data_import:import_preview"))
+        next_url = _safe_next_url(request, "plugins:netbox_data_import:import_preview")
 
         if profile_id and source_id:
             IgnoredDevice.objects.filter(
@@ -624,7 +635,7 @@ class SaveResolutionView(LoginRequiredMixin, View):
         source_column = request.POST.get("source_column")
         original_value = request.POST.get("original_value")
         resolved_fields_json = request.POST.get("resolved_fields", "{}")
-        next_url = request.POST.get("next", reverse("plugins:netbox_data_import:import_preview"))
+        next_url = _safe_next_url(request, "plugins:netbox_data_import:import_preview")
 
         try:
             resolved_fields = json.loads(resolved_fields_json)

--- a/netbox_data_import/views.py
+++ b/netbox_data_import/views.py
@@ -1347,6 +1347,37 @@ class SearchNetBoxObjectsView(LoginRequiredMixin, View):
         return JsonResponse({"results": results})
 
 
+def _auto_match_single_device(Device, profile, source_id, device_name, serial, asset_tag):
+    """Try to match a single device row to an existing NetBox device.
+
+    Returns (device_or_None, is_ambiguous).  Matching priority: serial →
+    asset_tag → exact name.  Multiple matches on any field → ambiguous.
+    """
+    device = None
+    if serial:
+        qs = Device.objects.filter(serial=serial)
+        if qs.count() == 1:
+            device = qs.first()
+        elif qs.count() > 1:
+            return None, True
+
+    if device is None and asset_tag:
+        qs = Device.objects.filter(asset_tag=asset_tag)
+        if qs.count() == 1:
+            device = qs.first()
+        elif qs.count() > 1:
+            return None, True
+
+    if device is None and device_name:
+        qs = Device.objects.filter(name=device_name)
+        if qs.count() == 1:
+            device = qs.first()
+        elif qs.count() > 1:
+            return None, True
+
+    return device, False
+
+
 class AutoMatchDevicesView(LoginRequiredMixin, View):
     """Scan all device rows in the session and auto-match to existing NetBox devices.
 
@@ -1378,33 +1409,10 @@ class AutoMatchDevicesView(LoginRequiredMixin, View):
                 already += 1
                 continue
 
-            device = None
-            # 1. Match by serial
-            if serial:
-                qs = Device.objects.filter(serial=serial)
-                if qs.count() == 1:
-                    device = qs.first()
-                elif qs.count() > 1:
-                    ambiguous += 1
-                    continue
-
-            # 2. Match by asset_tag
-            if device is None and asset_tag:
-                qs = Device.objects.filter(asset_tag=asset_tag)
-                if qs.count() == 1:
-                    device = qs.first()
-                elif qs.count() > 1:
-                    ambiguous += 1
-                    continue
-
-            # 3. Exact name match
-            if device is None and device_name:
-                qs = Device.objects.filter(name=device_name)
-                if qs.count() == 1:
-                    device = qs.first()
-                elif qs.count() > 1:
-                    ambiguous += 1
-                    continue
+            device, is_ambiguous = _auto_match_single_device(Device, profile, source_id, device_name, serial, asset_tag)
+            if is_ambiguous:
+                ambiguous += 1
+                continue
 
             if device is not None:
                 DeviceExistingMatch.objects.create(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ pythonpath = ["/opt/netbox/netbox"]
 line-length = 120
 
 [tool.ruff.lint]
-select = ["E", "F", "D"]
+select = ["E", "F", "W", "D", "C901"]
 ignore = [
     "E501",   # line too long (handled by formatter)
     "F403",   # star imports
@@ -60,11 +60,17 @@ ignore = [
     "D213",   # multi-line summary second line (conflicts with D212)
 ]
 
+[tool.ruff.lint.mccabe]
+max-complexity = 15
+
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
 "*/migrations/*.py" = ["D"]
 "*/tests/*.py" = ["D"]
 ".devcontainer/**" = ["D"]
+".devcontainer/scripts/test-e2e.py" = ["C901"]
+".devcontainer/scripts/test-e2e-preview.py" = ["C901"]
+".devcontainer/scripts/load-sample-data.py" = ["C901"]
 
 [tool.coverage.run]
 source = ["netbox_data_import"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ source = ["netbox_data_import"]
 omit = ["*/migrations/*", "*/tests/*"]
 
 [tool.coverage.report]
-fail_under = 80
+fail_under = 98
 show_missing = true
 
 [tool.semantic_release]


### PR DESCRIPTION
- Add process-helpers.sh with graceful_kill_pid, graceful_kill_pattern, and is_expected_pid for safe process management
- Derive PLUGIN_DIR from BASH_SOURCE instead of hardcoded path
- Add CA bundle var cleanup for Compose/devcontainer empty var injection
- Rewrite netbox-stop with is_expected_pid validation and graceful kill
- Add RQ worker management (start, stop, status, logs)
- Add rq-stats, rq-jobs, rq-failed, rq-recent inspection commands
- Use uv/pip fallback in netbox-reload, plugin-install, setup.sh
- Fix superuser creation to use os.environ (avoids shell injection)
- Add robust CA cert validation (cert_count, csplit status checks)
- Enhance diagnose.sh with PLUGIN_WS_DIR derivation, empty PID check, more env info, /proc/net/tcp fallback for port check
- Enhance welcome.sh with PLUGIN_WS_DIR, Codespaces URL, GitHub CLI status
- Fix copy-paste bugs: PLUGIN_DISPLAY, devcontainer name, banner, config description all now correctly say "Data Import" instead of "Interface Name Rules"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New devcontainer commands and aliases for plugin lifecycle, background jobs, diagnostics, and RQ inspection.
  * Background RQ worker support and enhanced startup/stop commands.

* **Improvements**
  * Rebranded devcontainer to "Data Import" with Codespaces-aware guidance and CA/installer handling.
  * Safer process/PID handling, improved startup messages, and diagnostics.
  * Structured multi-pass import runner, centralized single-device auto-match, and safer redirect handling.
  * Import jobs now link to their associated profile view.

* **Tests**
  * Large expansion of unit and API tests covering engine, views, matching, previews, imports, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->