### PR TITLE
fix: surface missing device role on preview and form validation

### DIFF
--- a/netbox_data_import/engine.py
+++ b/netbox_data_import/engine.py
@@ -1401,6 +1401,34 @@ def _pass3_process_devices(rows, ctx, class_role_map):
             )
             continue
 
+        if not crm.role_slug:
+            ctx.result.rows.append(
+                RowResult(
+                    row_number=row["_row_number"],
+                    source_id=source_id,
+                    name=device_name,
+                    action="error",
+                    object_type="device",
+                    detail=(
+                        f"Class '{device_class}' has no device role configured "
+                        "— edit the class→role mapping to set a role slug"
+                    ),
+                    rack_name=rack_name,
+                    extra_data={
+                        "source_class": device_class,
+                        "profile_id": ctx.profile.pk,
+                        "source_make": make,
+                        "source_model": model,
+                        "asset_tag": asset_tag or "",
+                        "mfg_slug": mfg_slug,
+                        "dt_slug": dt_slug,
+                        "u_height": u_height,
+                        "is_explicit_mapping": is_explicit_mapping,
+                    },
+                )
+            )
+            continue
+
         device_status = status_map.get(_str_val(row.get("status")).lower(), "active")
         device_face = side_map.get(_str_val(row.get("face")).lower())
         device_airflow = airflow_map.get(_str_val(row.get("airflow")).lower())

--- a/netbox_data_import/forms.py
+++ b/netbox_data_import/forms.py
@@ -63,6 +63,19 @@ class ClassRoleMappingForm(forms.ModelForm):
         fields = ["profile", "source_class", "creates_rack", "rack_type", "role_slug", "ignore"]
         widgets = {"profile": forms.HiddenInput()}
 
+    def clean(self):
+        """Require role_slug unless creates_rack or ignore is set."""
+        cleaned = super().clean()
+        creates_rack = cleaned.get("creates_rack")
+        ignore = cleaned.get("ignore")
+        role_slug = (cleaned.get("role_slug") or "").strip()
+        if not creates_rack and not ignore and not role_slug:
+            self.add_error(
+                "role_slug",
+                "A device role slug is required unless 'creates rack' or 'ignore' is checked.",
+            )
+        return cleaned
+
 
 class DeviceTypeMappingForm(forms.ModelForm):
     """Form for creating and editing DeviceTypeMapping instances."""

--- a/netbox_data_import/tests/test_engine_extended.py
+++ b/netbox_data_import/tests/test_engine_extended.py
@@ -2084,3 +2084,124 @@ class PermissionDeniedEngineTest(TestCase):
         )
         self.assertEqual(result.action, "error")
         self.assertIn("dcim.change_device", result.detail)
+
+
+class MissingRoleSlugErrorTest(TestCase):
+    """Class mapping with no role_slug must surface as preview/sync error, not crash."""
+
+    def setUp(self):
+        from dcim.models import Site
+
+        self.site = Site.objects.create(name="MissingRoleSite", slug="missing-role-site")
+        self.profile = ImportProfile.objects.create(name="MissingRoleProfile")
+        for src, tgt in {
+            "Id": "source_id",
+            "Rack": "rack_name",
+            "Name": "device_name",
+            "Class": "device_class",
+            "Make": "make",
+            "Model": "model",
+            "UHeight": "u_height",
+            "UPosition": "u_position",
+        }.items():
+            ColumnMapping.objects.create(profile=self.profile, source_column=src, target_field=tgt)
+        # Class mapping with NO role_slug, NOT creating a rack, NOT ignored — invalid state.
+        ClassRoleMapping.objects.create(
+            profile=self.profile,
+            source_class="Patch Panel",
+            creates_rack=False,
+            ignore=False,
+            role_slug="",
+        )
+
+    def _row(self):
+        return {
+            "_row_number": 2,
+            "source_id": "307359",
+            "rack_name": "V1",
+            "device_name": "DH4-V1-52-F",
+            "device_class": "Patch Panel",
+            "make": "Commscope",
+            "model": "Systimax 360G2-1U-MOD-FX",
+            "u_height": 1,
+            "u_position": 52,
+        }
+
+    def test_preview_reports_missing_role_error(self):
+        result = run_import([self._row()], self.profile, {"site": self.site}, dry_run=True)
+        device_rows = [r for r in result.rows if r.object_type == "device"]
+        self.assertEqual(len(device_rows), 1)
+        self.assertEqual(device_rows[0].action, "error")
+        self.assertIn("no device role configured", device_rows[0].detail)
+
+    def test_sync_does_not_crash_with_missing_role(self):
+        """Execute path must error gracefully, not raise DeviceRole.DoesNotExist."""
+        result = run_import([self._row()], self.profile, {"site": self.site}, dry_run=False)
+        device_rows = [r for r in result.rows if r.object_type == "device"]
+        self.assertEqual(len(device_rows), 1)
+        self.assertEqual(device_rows[0].action, "error")
+        self.assertIn("no device role configured", device_rows[0].detail)
+
+
+class ClassRoleMappingFormValidationTest(TestCase):
+    """Form-level validation: role_slug required unless creates_rack/ignore set."""
+
+    def setUp(self):
+        self.profile = ImportProfile.objects.create(name="FormValidProfile")
+
+    def test_form_rejects_empty_role_slug_when_no_other_action(self):
+        from netbox_data_import.forms import ClassRoleMappingForm
+
+        form = ClassRoleMappingForm(
+            data={
+                "profile": self.profile.pk,
+                "source_class": "Server",
+                "creates_rack": False,
+                "ignore": False,
+                "role_slug": "",
+            }
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("role_slug", form.errors)
+
+    def test_form_accepts_empty_role_slug_when_creates_rack(self):
+        from netbox_data_import.forms import ClassRoleMappingForm
+
+        form = ClassRoleMappingForm(
+            data={
+                "profile": self.profile.pk,
+                "source_class": "Cabinet",
+                "creates_rack": True,
+                "ignore": False,
+                "role_slug": "",
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_form_accepts_empty_role_slug_when_ignore(self):
+        from netbox_data_import.forms import ClassRoleMappingForm
+
+        form = ClassRoleMappingForm(
+            data={
+                "profile": self.profile.pk,
+                "source_class": "Misc",
+                "creates_rack": False,
+                "ignore": True,
+                "role_slug": "",
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_form_accepts_role_slug(self):
+        from netbox_data_import.forms import ClassRoleMappingForm
+
+        form = ClassRoleMappingForm(
+            data={
+                "profile": self.profile.pk,
+                "source_class": "Server",
+                "creates_rack": False,
+                "ignore": False,
+                "role_slug": "server",
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)


### PR DESCRIPTION
## Problem

When a `ClassRoleMapping` had `creates_rack=False` and `ignore=False` but no `role_slug`, the import preview happily showed 'Would create device …' but the actual sync (single-row or batch) crashed with:

```
Device role not found: device role not found
```

The user had no way to know the role was missing until clicking sync.

## Fix — defense in depth

1. **engine (`engine.py`)** — In pass 3 (`_pass3_process_devices`), after the `ignore` check, surface an error row when `crm.role_slug` is empty. Both preview (`dry_run=True`) and execute (`dry_run=False`) paths now produce the same actionable message:

   > Class 'Patch Panel' has no device role configured — edit the class→role mapping to set a role slug

2. **forms (`forms.py`)** — `ClassRoleMappingForm.clean()` rejects saving a mapping that has `creates_rack=False`, `ignore=False`, and an empty `role_slug`.

## Tests

- `MissingRoleSlugErrorTest` (2 tests): preview + sync surface the same clear error, no `DeviceRole.DoesNotExist` raised.
- `ClassRoleMappingFormValidationTest` (4 tests): form rejects empty role slug, accepts when `creates_rack` or `ignore` set, accepts valid slug.

558 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Device role validation is now enforced in class-to-role mappings. When a mapping lacks a configured device role, the system produces a clear error and prevents further processing.
  * Form validation ensures device role configuration is provided, with exceptions when specific override options are enabled.

* **Tests**
  * Added comprehensive test coverage for device role validation scenarios in both preview and execution modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marcinpsk/netbox-data-import-plugin/pull/30)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->