### PR TITLE
feat(split-modal): field preview and conflict detection

### DIFF
--- a/netbox_data_import/templates/netbox_data_import/import_preview.html
+++ b/netbox_data_import/templates/netbox_data_import/import_preview.html
@@ -1141,9 +1141,86 @@ function _addResolutionPart(container, idx, value, defaultField, fileResolvedFie
   _updateSaveButton();
 }
 
-// Stubs — replaced in Task 5
-function _checkPartConflict(idx, fileResolvedFields) {}
-function _updateSaveButton() {}
+function _checkPartConflict(idx, fileResolvedFields) {
+  var previewDiv = document.getElementById('res_part_preview_' + idx);
+  if (!previewDiv) return;
+  var fieldSelect = document.getElementById('res_part_field_' + idx);
+  var valueInput = document.getElementById('res_part_val_' + idx);
+  if (!fieldSelect || !valueInput) return;
+
+  var field = fieldSelect.value;
+  var splitValue = valueInput.value.trim();
+  var sourceColumn = document.getElementById('res_source_column').value; // always 'device_name'
+
+  previewDiv.innerHTML = '';
+  previewDiv.className = 'mt-2 p-2 rounded small';
+
+  if (!field) {
+    previewDiv.style.cssText = '';
+    return;
+  }
+
+  // Field is the column being split — no conflict possible
+  if (field === sourceColumn) {
+    previewDiv.style.cssText = 'background:#f8f9fa;border:1px solid #dee2e6;color:#6c757d;';
+    previewDiv.textContent = '(Replacing this column — no conflict possible)';
+    return;
+  }
+
+  var existingValue = ((fileResolvedFields || {})[field] || '').trim();
+
+  if (!existingValue) {
+    previewDiv.style.cssText = 'background:#d1e7dd;border:1px solid #badbcc;color:#0a3622;';
+    previewDiv.innerHTML = '<i class="mdi mdi-check-circle-outline"></i> Empty in file — will use split result.';
+    return;
+  }
+
+  if (existingValue.toLowerCase() === splitValue.toLowerCase()) {
+    previewDiv.style.cssText = 'background:#d1e7dd;border:1px solid #badbcc;color:#0a3622;';
+    previewDiv.innerHTML = '<i class="mdi mdi-check-circle-outline"></i> Matches file value: <code>' + _escHtml(existingValue) + '</code>';
+    return;
+  }
+
+  // Conflict: non-empty existing value differs from split result
+  previewDiv.style.cssText = 'background:#f8d7da;border:1px solid #f5c2c7;color:#842029;';
+  previewDiv.innerHTML =
+    '<strong><i class="mdi mdi-alert-circle-outline"></i> Conflict:</strong> ' +
+    'File has <code>' + _escHtml(existingValue) + '</code>, ' +
+    'split would set <code>' + _escHtml(splitValue) + '</code><br>' +
+    '<div class="form-check mt-1">' +
+      '<input class="form-check-input" type="checkbox" id="res_force_' + idx + '">' +
+      '<label class="form-check-label fw-semibold" for="res_force_' + idx + '">' +
+        'Force override (use split result, discard file value)' +
+      '</label>' +
+    '</div>';
+  var cb = document.getElementById('res_force_' + idx);
+  if (cb) { cb.addEventListener('change', _updateSaveButton); }
+}
+
+function _updateSaveButton() {
+  var saveBtn = document.querySelector('#splitNameModal button[type="submit"]');
+  var alertDiv = document.getElementById('res_conflict_alert');
+  var container = document.getElementById('res_parts_row');
+  if (!container) return;
+
+  var hasUnresolved = false;
+  var cols = container.querySelectorAll('[id^="res_part_preview_"]');
+  cols.forEach(function(previewDiv) {
+    var idxMatch = previewDiv.id.match(/res_part_preview_(\d+)/);
+    if (!idxMatch) return;
+    var idx = idxMatch[1];
+    var cb = document.getElementById('res_force_' + idx);
+    if (cb && !cb.checked) { hasUnresolved = true; }
+  });
+
+  if (saveBtn) {
+    saveBtn.disabled = hasUnresolved;
+    saveBtn.classList.toggle('disabled', hasUnresolved);
+  }
+  if (alertDiv) {
+    alertDiv.classList.toggle('d-none', !hasUnresolved);
+  }
+}
 
 function checkDevice(name) {
   var div = document.getElementById('res_device_check');
@@ -1186,6 +1263,18 @@ function checkDevice(name) {
 function buildResolvedFields() {
   var container = document.getElementById('res_parts_row');
   var parts = container.querySelectorAll('.col-md-6');
+
+  // Guard: block save if any conflict is unacknowledged
+  var hasUnresolved = false;
+  parts.forEach(function(col, idx) {
+    var cb = document.getElementById('res_force_' + idx);
+    if (cb && !cb.checked) { hasUnresolved = true; }
+  });
+  if (hasUnresolved) {
+    _updateSaveButton();
+    return false;
+  }
+
   var fields = {};
   parts.forEach(function(col, idx) {
     var val = document.getElementById('res_part_val_' + idx).value.trim();

--- a/netbox_data_import/templates/netbox_data_import/import_preview.html
+++ b/netbox_data_import/templates/netbox_data_import/import_preview.html
@@ -744,7 +744,7 @@
             <label class="form-label">Delimiter</label>
             <input type="text" class="form-control form-control-sm w-auto d-inline-block"
                    id="res_delimiter" value=" - " style="min-width:80px;"
-                   oninput="reSplit()">
+                   oninput="reSplit(window._currentFileResolvedFields || {})">
           </div>
 
           <div id="res_existing_notice" class="alert alert-info py-2 mb-3 d-none">
@@ -942,15 +942,16 @@ document.addEventListener('DOMContentLoaded', function() {
     document.getElementById('res_original_value').value = btn.dataset.originalValue;
     document.getElementById('res_original_display').textContent = btn.dataset.originalValue;
 
-    // Check for existing resolution and pre-populate
+    var fileResolvedFields = SPLIT_FIELD_VALUES[sourceId] || {};
+    window._currentFileResolvedFields = fileResolvedFields;
+
     var existing = (EXISTING_RESOLUTIONS[sourceId] || {})[sourceColumn];
     document.getElementById('res_existing_notice').classList.toggle('d-none', !existing);
     if (existing) {
       document.getElementById('res_existing_display').textContent = JSON.stringify(existing.resolved_fields);
-      // Pre-populate using existing resolved fields instead of auto-split
-      reSplitWithExisting(btn.dataset.originalValue, existing.resolved_fields);
+      reSplitWithExisting(btn.dataset.originalValue, existing.resolved_fields, fileResolvedFields);
     } else {
-      reSplit();
+      reSplit(fileResolvedFields);
     }
   });
 
@@ -1053,38 +1054,33 @@ document.addEventListener('DOMContentLoaded', function() {
 
 });
 
-function reSplit() {
+function reSplit(fileResolvedFields) {
+  fileResolvedFields = fileResolvedFields || {};
   var originalValue = document.getElementById('res_original_value').value;
   var delimiter = document.getElementById('res_delimiter').value || ' - ';
   var parts = originalValue.split(delimiter);
   var container = document.getElementById('res_parts_row');
   container.innerHTML = '';
 
-  // Default field assignments: left → asset_tag, right → device_name
   var defaultFields = ['asset_tag', 'device_name'];
-
   parts.forEach(function(part, idx) {
-    _addResolutionPart(container, idx, part.trim(), defaultFields[idx] || '');
+    _addResolutionPart(container, idx, part.trim(), defaultFields[idx] || '', fileResolvedFields);
   });
 }
 
-function reSplitWithExisting(originalValue, resolvedFields) {
-  // Reverse-map: field → value
+function reSplitWithExisting(originalValue, resolvedFields, fileResolvedFields) {
+  fileResolvedFields = fileResolvedFields || {};
   var delimiter = document.getElementById('res_delimiter').value || ' - ';
   var parts = originalValue.split(delimiter);
   var container = document.getElementById('res_parts_row');
   container.innerHTML = '';
 
-  // Default field assignments mirror reSplit() so unrecorded parts get a
-  // sensible field pre-selected rather than an empty dropdown.
   var defaultFields = ['asset_tag', 'device_name'];
-
-  // Build ordered list of resolved entries
   var entries = Object.entries(resolvedFields);
   parts.forEach(function(part, idx) {
     var field = entries[idx] ? entries[idx][0] : (defaultFields[idx] || '');
     var val = entries[idx] ? entries[idx][1] : part.trim();
-    _addResolutionPart(container, idx, val, field);
+    _addResolutionPart(container, idx, val, field, fileResolvedFields);
   });
 }
 

--- a/netbox_data_import/templates/netbox_data_import/import_preview.html
+++ b/netbox_data_import/templates/netbox_data_import/import_preview.html
@@ -757,6 +757,11 @@
             {# Dynamically populated parts #}
           </div>
 
+          <div id="res_conflict_alert" class="alert alert-warning py-2 mt-3 mb-0 small d-none">
+            <i class="mdi mdi-lock-outline"></i>
+            Cannot save: resolve all field conflicts above (check "Force override") before saving.
+          </div>
+
           <div id="res_device_check" class="mt-3 d-none">
             <small class="text-muted" id="res_device_check_msg"></small>
           </div>
@@ -817,6 +822,7 @@
 {{ device_match_info|json_script:"ndi-device-match-info" }}
 {{ conflicts_by_row|json_script:"ndi-conflicts-by-row" }}
 {{ extra_columns_by_row|json_script:"ndi-extra-columns-by-row" }}
+{{ split_field_values_by_source_id|json_script:"ndi-split-field-values" }}
 <script>
 // ── Row filter ──────────────────────────────────────────────────────────────
 (function() {
@@ -888,6 +894,15 @@ var TARGET_FIELDS = [
   ['source_id', 'Source ID'],
 ];
 
+function _escHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 // Existing saved resolutions keyed by source_id → source_column → {original_value, resolved_fields}
 var EXISTING_RESOLUTIONS = JSON.parse(document.getElementById('ndi-existing-resolutions').textContent);
 
@@ -895,6 +910,11 @@ var EXISTING_RESOLUTIONS = JSON.parse(document.getElementById('ndi-existing-reso
 // Issue 1: Add null check for element to prevent uncaught errors
 var scriptElement = document.getElementById('ndi-device-match-info');
 var DEVICE_MATCH_INFO = scriptElement ? JSON.parse(scriptElement.textContent) : {};
+
+// Resolved field values per source_id for split modal conflict detection
+var SPLIT_FIELD_VALUES = JSON.parse(
+  (document.getElementById('ndi-split-field-values') || {textContent: '{}'}).textContent
+);
 
 // Modal event listeners (Bootstrap 5 pattern — no global bootstrap var needed)
 document.addEventListener('DOMContentLoaded', function() {

--- a/netbox_data_import/templates/netbox_data_import/import_preview.html
+++ b/netbox_data_import/templates/netbox_data_import/import_preview.html
@@ -912,9 +912,8 @@ var scriptElement = document.getElementById('ndi-device-match-info');
 var DEVICE_MATCH_INFO = scriptElement ? JSON.parse(scriptElement.textContent) : {};
 
 // Resolved field values per source_id for split modal conflict detection
-var SPLIT_FIELD_VALUES = JSON.parse(
-  (document.getElementById('ndi-split-field-values') || {textContent: '{}'}).textContent
-);
+var splitFieldValuesEl = document.getElementById('ndi-split-field-values');
+var SPLIT_FIELD_VALUES = splitFieldValuesEl ? JSON.parse(splitFieldValuesEl.textContent) : {};
 
 // Modal event listeners (Bootstrap 5 pattern — no global bootstrap var needed)
 document.addEventListener('DOMContentLoaded', function() {
@@ -1182,6 +1181,10 @@ function _checkPartConflict(idx, fileResolvedFields) {
   }
 
   // Conflict: non-empty existing value differs from split result
+  // Snapshot force-checkbox state before innerHTML replacement
+  var prevCb = document.getElementById('res_force_' + idx);
+  var prevChecked = prevCb ? prevCb.checked : false;
+
   previewDiv.style.cssText = 'background:#f8d7da;border:1px solid #f5c2c7;color:#842029;';
   previewDiv.innerHTML =
     '<strong><i class="mdi mdi-alert-circle-outline"></i> Conflict:</strong> ' +
@@ -1193,8 +1196,14 @@ function _checkPartConflict(idx, fileResolvedFields) {
         'Force override (use split result, discard file value)' +
       '</label>' +
     '</div>';
+
+  // Restore state and re-attach listener (old element was destroyed)
   var cb = document.getElementById('res_force_' + idx);
-  if (cb) { cb.addEventListener('change', _updateSaveButton); }
+  if (cb) {
+    cb.checked = prevChecked;
+    cb.addEventListener('change', _updateSaveButton);
+  }
+  _updateSaveButton();
 }
 
 function _updateSaveButton() {

--- a/netbox_data_import/templates/netbox_data_import/import_preview.html
+++ b/netbox_data_import/templates/netbox_data_import/import_preview.html
@@ -1084,9 +1084,11 @@ function reSplitWithExisting(originalValue, resolvedFields, fileResolvedFields) 
   });
 }
 
-function _addResolutionPart(container, idx, value, defaultField) {
+function _addResolutionPart(container, idx, value, defaultField, fileResolvedFields) {
+  fileResolvedFields = fileResolvedFields || {};
   var col = document.createElement('div');
   col.className = 'col-md-6';
+  col.id = 'res_part_col_' + idx;
 
   var label = document.createElement('label');
   label.className = 'form-label';
@@ -1109,7 +1111,20 @@ function _addResolutionPart(container, idx, value, defaultField) {
     select.appendChild(opt);
   });
 
-  // Check device name existence on change
+  var previewDiv = document.createElement('div');
+  previewDiv.id = 'res_part_preview_' + idx;
+
+  // Conflict + preview re-check on every value or field change
+  input.addEventListener('input', function() {
+    _checkPartConflict(idx, fileResolvedFields);
+    _updateSaveButton();
+  });
+  select.addEventListener('change', function() {
+    _checkPartConflict(idx, fileResolvedFields);
+    _updateSaveButton();
+  });
+
+  // Existing: device name existence check for part 2
   if (idx === 1) {
     input.addEventListener('input', function() { checkDevice(input.value); });
     checkDevice(input.value);
@@ -1118,8 +1133,17 @@ function _addResolutionPart(container, idx, value, defaultField) {
   col.appendChild(label);
   col.appendChild(input);
   col.appendChild(select);
+  col.appendChild(previewDiv);
   container.appendChild(col);
+
+  // Render initial preview state
+  _checkPartConflict(idx, fileResolvedFields);
+  _updateSaveButton();
 }
+
+// Stubs — replaced in Task 5
+function _checkPartConflict(idx, fileResolvedFields) {}
+function _updateSaveButton() {}
 
 function checkDevice(name) {
   var div = document.getElementById('res_device_check');

--- a/netbox_data_import/views.py
+++ b/netbox_data_import/views.py
@@ -801,7 +801,7 @@ class ImportPreviewView(PermissionRequiredMixin, View):
                 "make": r.extra_data.get("source_make", ""),
                 "model": r.extra_data.get("source_model", ""),
                 "rack_name": r.rack_name or "",
-                "source_id": r.source_id or "",
+                "source_id": r.source_id,
             }
             for r in result.rows
             if r.object_type == "device" and r.source_id

--- a/netbox_data_import/views.py
+++ b/netbox_data_import/views.py
@@ -793,6 +793,19 @@ class ImportPreviewView(PermissionRequiredMixin, View):
             for r in result.rows
             if r.extra_data.get("extra_columns")
         }
+        split_field_values_by_source_id = {
+            r.source_id: {
+                "device_name": r.name or "",
+                "asset_tag": r.extra_data.get("asset_tag", ""),
+                "serial": r.extra_data.get("source_serial", ""),
+                "make": r.extra_data.get("source_make", ""),
+                "model": r.extra_data.get("source_model", ""),
+                "rack_name": r.rack_name or "",
+                "source_id": r.source_id or "",
+            }
+            for r in result.rows
+            if r.object_type == "device" and r.source_id
+        }
 
         non_card_error_rows = [
             r
@@ -821,6 +834,7 @@ class ImportPreviewView(PermissionRequiredMixin, View):
                 "device_match_info": device_match_info,
                 "conflicts_by_row": conflicts_by_row,
                 "extra_columns_by_row": extra_columns_by_row,
+                "split_field_values_by_source_id": split_field_values_by_source_id,
                 "non_card_error_rows": non_card_error_rows,
             },
         )


### PR DESCRIPTION
## Summary

- **Field preview in Split Name modal**: when mapping a split part to a target field, the modal now shows what the engine already resolved for that field from the import file
- **Conflict detection**: if a split result would overwrite a non-empty resolved value, Save is blocked with a red warning; user must check a per-part "Force override" checkbox to proceed
- **Save guard**: double-protected — DOM button disabled + `buildResolvedFields()` returns false until all conflicts are acknowledged
- **Fix**: force-checkbox state is preserved when the user edits the value field (re-render no longer resets the checkbox)

## Conflict states

| State | Colour | Behaviour |
|---|---|---|
| No field selected | — | Preview cleared |
| Field is the source column | grey | "Replacing this column" note |
| File value is empty | green | "Empty in file" |
| Split result matches file value | green | "Matches file value" |
| Non-empty, differs | red | Conflict message + Force override checkbox; **blocks Save** |

## Test plan
- [x] 584 unit tests pass
- [x] Playwright: Scenario A — empty asset_tag → Save enabled
- [x] Playwright: Scenario B — conflict → Save blocked → Force override → enabled
- [x] Playwright: Scenario C — device_name target → "Replacing this column" note

## Files changed
- `netbox_data_import/views.py` — `split_field_values_by_source_id` context variable
- `netbox_data_import/templates/netbox_data_import/import_preview.html` — JS conflict detection logic


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The "Split Name — Save Resolution" modal now detects when field values would conflict and prevents saving until all conflicts are explicitly resolved.
  * Added an inline alert guiding users to resolve conflicts before saving is permitted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marcinpsk/netbox-data-import-plugin/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->