### PR TITLE
feat(sync): rack sync, face dependency guard, and atomic placement sync

### DIFF
--- a/netbox_data_import/templates/netbox_data_import/import_preview.html
+++ b/netbox_data_import/templates/netbox_data_import/import_preview.html
@@ -662,6 +662,20 @@
             <tr id="diff-{{ row.row_number }}" class="ndi-diff-row">
               <td colspan="7" class="p-0 border-top-0">
                 <div class="px-3 py-2" style="background: var(--tblr-bg-surface-secondary, rgba(0,0,0,0.02));">
+                  {% if row.rack_name %}
+                  <div class="mb-2">
+                    <button type="button" class="btn btn-xs btn-outline-success ndi-sync-placement-btn"
+                            data-device-id="{{ row.extra_data.netbox_device_id }}"
+                            data-rack-name="{{ row.rack_name }}"
+                            data-u-position="{{ row.extra_data.u_position|default:'' }}"
+                            data-face="{{ row.extra_data.face|default:'' }}"
+                            data-row-id="{{ row.row_number }}"
+                            title="Set rack{% if row.extra_data.u_position %}, position{% endif %}{% if row.extra_data.face %}, face{% endif %} atomically">
+                      <i class="mdi mdi-package-variant"></i> Sync placement
+                    </button>
+                    <span class="text-muted small ms-2">rack=<strong>{{ row.rack_name }}</strong>{% if row.extra_data.u_position %}, U{{ row.extra_data.u_position }}{% endif %}{% if row.extra_data.face %}, {{ row.extra_data.face }}{% endif %}</span>
+                  </div>
+                  {% endif %}
                   <table class="table table-sm table-borderless ndi-diff-table mb-0">
                     <thead>
                       <tr class="text-muted">
@@ -2226,6 +2240,60 @@ document.addEventListener('click', function(e) {
     btn.title = 'Network error — sync failed';
     btn.classList.add('btn-danger');
     btn.classList.remove('btn-outline-primary');
+  });
+});
+
+// Sync placement bundle (rack + position + face atomic)
+document.addEventListener('click', function(e) {
+  const btn = e.target.closest('.ndi-sync-placement-btn');
+  if (!btn) return;
+
+  const deviceId = btn.dataset.deviceId;
+  const rackName = btn.dataset.rackName;
+  const uPosition = btn.dataset.uPosition || '';
+  const face = btn.dataset.face || '';
+
+  const originalHTML = btn.innerHTML;
+  btn.disabled = true;
+  btn.innerHTML = '<i class="mdi mdi-loading mdi-spin"></i> Syncing...';
+
+  const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]')?.value || '';
+  const body = new URLSearchParams({
+    device_id: deviceId,
+    rack_name: rackName,
+    u_position: uPosition,
+    face: face,
+  });
+
+  fetch('{% url "plugins:netbox_data_import:sync_placement" %}', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'X-CSRFToken': csrfToken,
+    },
+    body: body.toString(),
+  })
+  .then(r => r.json())
+  .then(data => {
+    if (data.ok) {
+      btn.innerHTML = '<i class="mdi mdi-check"></i> Synced: ' + data.display;
+      btn.classList.remove('btn-outline-success');
+      btn.classList.add('btn-success');
+    } else {
+      btn.disabled = false;
+      btn.innerHTML = originalHTML;
+      btn.title = data.error || 'Placement sync failed';
+      btn.classList.add('btn-danger');
+      btn.classList.remove('btn-outline-success');
+      alert('Placement sync failed: ' + (data.error || 'unknown error'));
+    }
+  })
+  .catch(() => {
+    btn.disabled = false;
+    btn.innerHTML = originalHTML;
+    btn.title = 'Network error — placement sync failed';
+    btn.classList.add('btn-danger');
+    btn.classList.remove('btn-outline-success');
   });
 });
 </script>

--- a/netbox_data_import/templates/netbox_data_import/import_preview.html
+++ b/netbox_data_import/templates/netbox_data_import/import_preview.html
@@ -2276,7 +2276,12 @@ document.addEventListener('click', function(e) {
   .then(r => r.json())
   .then(data => {
     if (data.ok) {
-      btn.innerHTML = '<i class="mdi mdi-check"></i> Synced: ' + data.display;
+      // Build DOM nodes (not innerHTML) so data.display cannot inject markup.
+      while (btn.firstChild) btn.removeChild(btn.firstChild);
+      const icon = document.createElement('i');
+      icon.className = 'mdi mdi-check';
+      btn.appendChild(icon);
+      btn.appendChild(document.createTextNode(' Synced: ' + (data.display || '')));
       btn.classList.remove('btn-outline-success');
       btn.classList.add('btn-success');
     } else {

--- a/netbox_data_import/tests/test_views.py
+++ b/netbox_data_import/tests/test_views.py
@@ -1584,6 +1584,7 @@ class SearchNetBoxObjectsExtendedViewTest(BaseViewTestCase):
         self.assertEqual(resp.status_code, 200)
         data = json.loads(resp.content)
         names = [r["name"] for r in data["results"]]
+        self.assertEqual(len(names), 20, f"Expected 20-result cap, got {len(names)}: {names}")
         self.assertIn(target.name, names, f"Target device pushed off result list; got {names}")
 
     def test_device_serial_null_when_not_set(self):
@@ -3702,7 +3703,14 @@ class SyncRackAndPlacementTests(TestCase):
         self.assertEqual(self.device_no_loc.face, "front")
 
     def test_placement_rack_only(self):
-        """Placement with no position/face only sets the rack."""
+        """Placement with no position/face only sets the rack, leaving existing position/face intact."""
+        # Pre-seed: device already placed in the rack with a known position and face.
+        # Bypasses full_clean intentionally — we're setting up pre-existing DB state.
+        self.device_no_loc.rack = self.rack_no_loc
+        self.device_no_loc.position = 7
+        self.device_no_loc.face = "rear"
+        self.device_no_loc.save()
+
         resp = self.client.post(
             self.placement_url,
             {"device_id": self.device_no_loc.pk, "rack_name": "R1"},
@@ -3711,8 +3719,9 @@ class SyncRackAndPlacementTests(TestCase):
         self.assertTrue(data["ok"], data)
         self.device_no_loc.refresh_from_db()
         self.assertEqual(self.device_no_loc.rack_id, self.rack_no_loc.pk)
-        self.assertIsNone(self.device_no_loc.position)
-        self.assertFalse(self.device_no_loc.face)
+        # Unspecified fields must be preserved — only the fields in the POST are written.
+        self.assertEqual(self.device_no_loc.position, 7)
+        self.assertEqual(self.device_no_loc.face, "rear")
 
     def test_placement_atomic_on_rack_lookup_failure(self):
         """If rack lookup fails, no fields are changed."""

--- a/netbox_data_import/tests/test_views.py
+++ b/netbox_data_import/tests/test_views.py
@@ -3739,6 +3739,91 @@ class SyncRackAndPlacementTests(TestCase):
         )
         self.assertIn(resp.status_code, (302, 403))
 
+    def test_face_invalid_value_with_rack(self):
+        """Invalid face value with rack assigned hits the face mapping error path."""
+        self.device_no_loc.rack = self.rack_no_loc
+        self.device_no_loc.save()
+        resp = self.client.post(
+            self.field_url,
+            {"device_id": self.device_no_loc.pk, "field": "face", "value": "sideways"},
+        )
+        data = resp.json()
+        self.assertFalse(data["ok"])
+        self.assertIn("face", data["error"].lower())
+        self.device_no_loc.refresh_from_db()
+        self.assertFalse(self.device_no_loc.face)
+
+    def test_lookup_rack_device_with_no_site(self):
+        """_lookup_rack_for_device returns an error when device has no site."""
+        from netbox_data_import.views import _lookup_rack_for_device
+
+        class _Stub:
+            site_id = None
+            location_id = None
+            site = None
+            location = None
+
+        rack, err = _lookup_rack_for_device(_Stub(), "R1")
+        self.assertIsNone(rack)
+        self.assertIn("no site", err.lower())
+
+    def test_placement_bad_u_position(self):
+        """Non-integer u_position returns a clear error and does not save."""
+        resp = self.client.post(
+            self.placement_url,
+            {
+                "device_id": self.device_no_loc.pk,
+                "rack_name": "R1",
+                "u_position": "notanint",
+            },
+        )
+        data = resp.json()
+        self.assertFalse(data["ok"])
+        self.assertIn("u_position", data["error"])
+        self.device_no_loc.refresh_from_db()
+        self.assertIsNone(self.device_no_loc.rack_id)
+
+    def test_placement_validation_error(self):
+        """A u_position outside the rack u_height range triggers full_clean ValidationError."""
+        resp = self.client.post(
+            self.placement_url,
+            {
+                "device_id": self.device_no_loc.pk,
+                "rack_name": "R1",
+                "u_position": "9999",
+                "face": "front",
+            },
+        )
+        self.assertEqual(resp.status_code, 400)
+        data = resp.json()
+        self.assertFalse(data["ok"])
+        self.assertIn("Validation failed", data["error"])
+        self.device_no_loc.refresh_from_db()
+        self.assertIsNone(self.device_no_loc.rack_id)
+
+    def test_placement_save_exception(self):
+        """A save() failure returns a generic 500 JSON error and logs the exception."""
+        from unittest.mock import patch
+
+        from dcim.models import Device
+
+        original_save = Device.save
+
+        def boom(self, *a, **kw):
+            if "rack" in (kw.get("update_fields") or []):
+                raise RuntimeError("simulated db error")
+            return original_save(self, *a, **kw)
+
+        with patch.object(Device, "save", boom):
+            resp = self.client.post(
+                self.placement_url,
+                {"device_id": self.device_no_loc.pk, "rack_name": "R1"},
+            )
+        self.assertEqual(resp.status_code, 500)
+        data = resp.json()
+        self.assertFalse(data["ok"])
+        self.assertIn("internal error", data["error"].lower())
+
 
 class UnlinkDeviceViewTest(TestCase):
     """Test UnlinkDeviceView."""

--- a/netbox_data_import/tests/test_views.py
+++ b/netbox_data_import/tests/test_views.py
@@ -3514,6 +3514,205 @@ class SyncDeviceFieldViewTests(TestCase):
         self.assertIn("already exists", data["error"])
 
 
+class SyncRackAndPlacementTests(TestCase):
+    """Tests for rack_name sync, face dependency guard, and SyncPlacementView."""
+
+    def setUp(self):
+        from dcim.models import Device, DeviceRole, DeviceType, Location, Manufacturer, Rack, Site
+
+        self.user = User.objects.create_superuser("testuser_placement", "p@example.com", "testpass")
+        self.client = Client()
+        self.client.login(username="testuser_placement", password="testpass")
+
+        self.site = Site.objects.create(name="PSite", slug="psite")
+        self.site2 = Site.objects.create(name="PSite2", slug="psite2")
+        self.location = Location.objects.create(name="PLoc", slug="ploc", site=self.site)
+        mfg = Manufacturer.objects.create(name="PMfg", slug="pmfg")
+        dt = DeviceType.objects.create(manufacturer=mfg, model="PModel", slug="pmodel", u_height=1)
+        role = DeviceRole.objects.create(name="PRole", slug="prole")
+        # Rack in site only (no location)
+        self.rack_no_loc = Rack.objects.create(name="R1", site=self.site, u_height=42)
+        # Rack in site + location
+        self.rack_with_loc = Rack.objects.create(name="R2", site=self.site, location=self.location, u_height=42)
+        # Same-named rack in a different site (must not match)
+        Rack.objects.create(name="R1", site=self.site2, u_height=42)
+        # Two racks with same name in same site (ambiguous)
+        self.amb_site = Site.objects.create(name="AmbSite", slug="ambsite")
+        Rack.objects.create(name="DUP", site=self.amb_site, u_height=42)
+        Rack.objects.create(name="DUP", site=self.amb_site, u_height=42)
+
+        self.device_no_loc = Device.objects.create(name="dev-noloc", site=self.site, device_type=dt, role=role)
+        self.device_with_loc = Device.objects.create(
+            name="dev-withloc", site=self.site, location=self.location, device_type=dt, role=role
+        )
+        self.device_amb = Device.objects.create(name="dev-amb", site=self.amb_site, device_type=dt, role=role)
+
+        self.field_url = reverse("plugins:netbox_data_import:sync_device_field")
+        self.placement_url = reverse("plugins:netbox_data_import:sync_placement")
+
+    def test_rack_name_sync_site_only(self):
+        """Device with no location matches rack with no location in same site."""
+        resp = self.client.post(
+            self.field_url,
+            {"device_id": self.device_no_loc.pk, "field": "rack_name", "value": "R1"},
+        )
+        data = resp.json()
+        self.assertTrue(data["ok"], data)
+        self.device_no_loc.refresh_from_db()
+        self.assertEqual(self.device_no_loc.rack_id, self.rack_no_loc.pk)
+
+    def test_rack_name_sync_with_location(self):
+        """Device with location matches rack in same location."""
+        resp = self.client.post(
+            self.field_url,
+            {"device_id": self.device_with_loc.pk, "field": "rack_name", "value": "R2"},
+        )
+        data = resp.json()
+        self.assertTrue(data["ok"], data)
+        self.device_with_loc.refresh_from_db()
+        self.assertEqual(self.device_with_loc.rack_id, self.rack_with_loc.pk)
+
+    def test_rack_name_sync_location_mismatch_not_found(self):
+        """Device with location does NOT match a rack without location (and vice versa)."""
+        resp = self.client.post(
+            self.field_url,
+            {"device_id": self.device_with_loc.pk, "field": "rack_name", "value": "R1"},
+        )
+        data = resp.json()
+        self.assertFalse(data["ok"])
+        self.assertIn("not found", data["error"])
+
+    def test_rack_name_sync_not_found(self):
+        resp = self.client.post(
+            self.field_url,
+            {"device_id": self.device_no_loc.pk, "field": "rack_name", "value": "DOESNOTEXIST"},
+        )
+        data = resp.json()
+        self.assertFalse(data["ok"])
+        self.assertIn("not found", data["error"])
+
+    def test_rack_name_sync_ambiguous(self):
+        resp = self.client.post(
+            self.field_url,
+            {"device_id": self.device_amb.pk, "field": "rack_name", "value": "DUP"},
+        )
+        data = resp.json()
+        self.assertFalse(data["ok"])
+        self.assertIn("Multiple", data["error"])
+
+    def test_rack_name_sync_empty(self):
+        resp = self.client.post(
+            self.field_url,
+            {"device_id": self.device_no_loc.pk, "field": "rack_name", "value": "   "},
+        )
+        data = resp.json()
+        self.assertFalse(data["ok"])
+        self.assertIn("empty", data["error"].lower())
+
+    def test_face_blocked_when_no_rack(self):
+        """Syncing face on a device with no rack returns a clear error and does not save."""
+        self.assertIsNone(self.device_no_loc.rack_id)
+        resp = self.client.post(
+            self.field_url,
+            {"device_id": self.device_no_loc.pk, "field": "face", "value": "front"},
+        )
+        data = resp.json()
+        self.assertFalse(data["ok"])
+        self.assertIn("no rack", data["error"].lower())
+        self.device_no_loc.refresh_from_db()
+        self.assertFalse(self.device_no_loc.face)
+
+    def test_face_works_when_rack_assigned(self):
+        self.device_no_loc.rack = self.rack_no_loc
+        self.device_no_loc.save()
+        resp = self.client.post(
+            self.field_url,
+            {"device_id": self.device_no_loc.pk, "field": "face", "value": "front"},
+        )
+        data = resp.json()
+        self.assertTrue(data["ok"], data)
+        self.device_no_loc.refresh_from_db()
+        self.assertEqual(self.device_no_loc.face, "front")
+
+    def test_placement_happy_path(self):
+        resp = self.client.post(
+            self.placement_url,
+            {
+                "device_id": self.device_no_loc.pk,
+                "rack_name": "R1",
+                "u_position": "5",
+                "face": "front",
+            },
+        )
+        data = resp.json()
+        self.assertTrue(data["ok"], data)
+        self.device_no_loc.refresh_from_db()
+        self.assertEqual(self.device_no_loc.rack_id, self.rack_no_loc.pk)
+        self.assertEqual(self.device_no_loc.position, 5)
+        self.assertEqual(self.device_no_loc.face, "front")
+
+    def test_placement_rack_only(self):
+        """Placement with no position/face only sets the rack."""
+        resp = self.client.post(
+            self.placement_url,
+            {"device_id": self.device_no_loc.pk, "rack_name": "R1"},
+        )
+        data = resp.json()
+        self.assertTrue(data["ok"], data)
+        self.device_no_loc.refresh_from_db()
+        self.assertEqual(self.device_no_loc.rack_id, self.rack_no_loc.pk)
+        self.assertIsNone(self.device_no_loc.position)
+        self.assertFalse(self.device_no_loc.face)
+
+    def test_placement_atomic_on_rack_lookup_failure(self):
+        """If rack lookup fails, no fields are changed."""
+        original_rack = self.device_no_loc.rack_id
+        original_pos = self.device_no_loc.position
+        resp = self.client.post(
+            self.placement_url,
+            {
+                "device_id": self.device_no_loc.pk,
+                "rack_name": "DOESNOTEXIST",
+                "u_position": "5",
+                "face": "front",
+            },
+        )
+        data = resp.json()
+        self.assertFalse(data["ok"])
+        self.device_no_loc.refresh_from_db()
+        self.assertEqual(self.device_no_loc.rack_id, original_rack)
+        self.assertEqual(self.device_no_loc.position, original_pos)
+        self.assertFalse(self.device_no_loc.face)
+
+    def test_placement_bad_face(self):
+        resp = self.client.post(
+            self.placement_url,
+            {"device_id": self.device_no_loc.pk, "rack_name": "R1", "face": "sideways"},
+        )
+        data = resp.json()
+        self.assertFalse(data["ok"])
+        self.assertIn("face", data["error"].lower())
+        self.device_no_loc.refresh_from_db()
+        # All-or-nothing: rack also not set
+        self.assertIsNone(self.device_no_loc.rack_id)
+
+    def test_placement_missing_device(self):
+        resp = self.client.post(self.placement_url, {"device_id": 99999, "rack_name": "R1"})
+        data = resp.json()
+        self.assertFalse(data["ok"])
+        self.assertIn("Device not found", data["error"])
+
+    def test_placement_requires_permission(self):
+        User.objects.create_user("no_perm_placement", "n@example.com", "testpass")
+        c = Client()
+        c.login(username="no_perm_placement", password="testpass")
+        resp = c.post(
+            self.placement_url,
+            {"device_id": self.device_no_loc.pk, "rack_name": "R1"},
+        )
+        self.assertIn(resp.status_code, (302, 403))
+
+
 class UnlinkDeviceViewTest(TestCase):
     """Test UnlinkDeviceView."""
 

--- a/netbox_data_import/tests/test_views.py
+++ b/netbox_data_import/tests/test_views.py
@@ -3504,12 +3504,25 @@ class SyncDeviceFieldViewTests(TestCase):
         self.assertIn("Device not found", data["error"])
 
     def test_sync_requires_permission(self):
-        """User without dcim.change_device is denied."""
+        """Authenticated user without dcim.change_device gets JSON 403."""
         User.objects.create_user("no_perm_sync", "noperm@example.com", "testpass")
         no_perm_client = Client()
         no_perm_client.login(username="no_perm_sync", password="testpass")
         response = no_perm_client.post(self.url, {"device_id": self.device.pk, "field": "serial", "value": "X"})
-        self.assertIn(response.status_code, (302, 403))
+        self.assertEqual(response.status_code, 403)
+        self.assertIn("application/json", response.get("Content-Type", ""))
+        data = response.json()
+        self.assertFalse(data["ok"])
+        self.assertIn("Permission denied", data["error"])
+
+    def test_sync_unauthenticated_gets_json_401(self):
+        """Unauthenticated request receives JSON 401 (not an HTML redirect)."""
+        c = Client()
+        response = c.post(self.url, {"device_id": self.device.pk, "field": "serial", "value": "X"})
+        self.assertEqual(response.status_code, 401)
+        self.assertIn("application/json", response.get("Content-Type", ""))
+        data = response.json()
+        self.assertFalse(data["ok"])
 
     def test_sync_asset_tag_clear(self):
         """Clearing asset_tag sets it to None (not empty string) to avoid UNIQUE violation."""
@@ -3578,10 +3591,10 @@ class SyncRackAndPlacementTests(TestCase):
         self.placement_url = reverse("plugins:netbox_data_import:sync_placement")
 
     def test_rack_name_sync_site_only(self):
-        """Device with no location matches rack with no location in same site."""
+        """Device with no location matches rack with no location in same site (via placement)."""
         resp = self.client.post(
-            self.field_url,
-            {"device_id": self.device_no_loc.pk, "field": "rack_name", "value": "R1"},
+            self.placement_url,
+            {"device_id": self.device_no_loc.pk, "rack_name": "R1"},
         )
         data = resp.json()
         self.assertTrue(data["ok"], data)
@@ -3589,10 +3602,10 @@ class SyncRackAndPlacementTests(TestCase):
         self.assertEqual(self.device_no_loc.rack_id, self.rack_no_loc.pk)
 
     def test_rack_name_sync_with_location(self):
-        """Device with location matches rack in same location."""
+        """Device with location matches rack in same location (via placement)."""
         resp = self.client.post(
-            self.field_url,
-            {"device_id": self.device_with_loc.pk, "field": "rack_name", "value": "R2"},
+            self.placement_url,
+            {"device_id": self.device_with_loc.pk, "rack_name": "R2"},
         )
         data = resp.json()
         self.assertTrue(data["ok"], data)
@@ -3602,8 +3615,8 @@ class SyncRackAndPlacementTests(TestCase):
     def test_rack_name_sync_location_mismatch_not_found(self):
         """Device with location does NOT match a rack without location (and vice versa)."""
         resp = self.client.post(
-            self.field_url,
-            {"device_id": self.device_with_loc.pk, "field": "rack_name", "value": "R1"},
+            self.placement_url,
+            {"device_id": self.device_with_loc.pk, "rack_name": "R1"},
         )
         data = resp.json()
         self.assertFalse(data["ok"])
@@ -3611,8 +3624,8 @@ class SyncRackAndPlacementTests(TestCase):
 
     def test_rack_name_sync_not_found(self):
         resp = self.client.post(
-            self.field_url,
-            {"device_id": self.device_no_loc.pk, "field": "rack_name", "value": "DOESNOTEXIST"},
+            self.placement_url,
+            {"device_id": self.device_no_loc.pk, "rack_name": "DOESNOTEXIST"},
         )
         data = resp.json()
         self.assertFalse(data["ok"])
@@ -3620,8 +3633,8 @@ class SyncRackAndPlacementTests(TestCase):
 
     def test_rack_name_sync_ambiguous(self):
         resp = self.client.post(
-            self.field_url,
-            {"device_id": self.device_amb.pk, "field": "rack_name", "value": "DUP"},
+            self.placement_url,
+            {"device_id": self.device_amb.pk, "rack_name": "DUP"},
         )
         data = resp.json()
         self.assertFalse(data["ok"])
@@ -3629,12 +3642,22 @@ class SyncRackAndPlacementTests(TestCase):
 
     def test_rack_name_sync_empty(self):
         resp = self.client.post(
-            self.field_url,
-            {"device_id": self.device_no_loc.pk, "field": "rack_name", "value": "   "},
+            self.placement_url,
+            {"device_id": self.device_no_loc.pk, "rack_name": "   "},
         )
         data = resp.json()
         self.assertFalse(data["ok"])
         self.assertIn("empty", data["error"].lower())
+
+    def test_rack_name_field_no_longer_in_single_field_sync(self):
+        """rack_name is not in _ALLOWED_FIELDS — use Sync Placement instead."""
+        resp = self.client.post(
+            self.field_url,
+            {"device_id": self.device_no_loc.pk, "field": "rack_name", "value": "R1"},
+        )
+        data = resp.json()
+        self.assertFalse(data["ok"])
+        self.assertIn("rack_name", data["error"])
 
     def test_face_blocked_when_no_rack(self):
         """Syncing face on a device with no rack returns a clear error and does not save."""
@@ -3730,6 +3753,7 @@ class SyncRackAndPlacementTests(TestCase):
         self.assertIn("Device not found", data["error"])
 
     def test_placement_requires_permission(self):
+        """Authenticated user without dcim.change_device gets JSON 403."""
         User.objects.create_user("no_perm_placement", "n@example.com", "testpass")
         c = Client()
         c.login(username="no_perm_placement", password="testpass")
@@ -3737,7 +3761,23 @@ class SyncRackAndPlacementTests(TestCase):
             self.placement_url,
             {"device_id": self.device_no_loc.pk, "rack_name": "R1"},
         )
-        self.assertIn(resp.status_code, (302, 403))
+        self.assertEqual(resp.status_code, 403)
+        self.assertIn("application/json", resp.get("Content-Type", ""))
+        data = resp.json()
+        self.assertFalse(data["ok"])
+        self.assertIn("Permission denied", data["error"])
+
+    def test_placement_unauthenticated_gets_json_401(self):
+        """Unauthenticated request receives JSON 401 (not an HTML redirect)."""
+        c = Client()
+        resp = c.post(
+            self.placement_url,
+            {"device_id": self.device_no_loc.pk, "rack_name": "R1"},
+        )
+        self.assertEqual(resp.status_code, 401)
+        self.assertIn("application/json", resp.get("Content-Type", ""))
+        data = resp.json()
+        self.assertFalse(data["ok"])
 
     def test_face_invalid_value_with_rack(self):
         """Invalid face value with rack assigned hits the face mapping error path."""
@@ -3877,16 +3917,13 @@ class UnlinkDeviceViewTest(TestCase):
         self.assertTrue(DeviceExistingMatch.objects.filter(pk=self.match.pk).exists())
 
     def test_unlink_unauthenticated(self):
-        """Unlink requires authentication."""
-        from django.conf import settings
-        from django.shortcuts import resolve_url
-
+        """Unauthenticated requests get JSON 401 (not a redirect)."""
         from netbox_data_import.models import DeviceExistingMatch
 
         resp = self.client.post(self.url, {"profile_id": self.profile.pk, "source_id": "SRC001"})
-        login_url = resolve_url(getattr(settings, "LOGIN_URL", "/login/"))
-        self.assertEqual(resp.status_code, 302)
-        self.assertTrue(str(resp.url).startswith(login_url))
+        self.assertEqual(resp.status_code, 401)
+        self.assertEqual(resp["Content-Type"], "application/json")
+        self.assertIn("error", resp.json())
         self.assertTrue(DeviceExistingMatch.objects.filter(pk=self.match.pk).exists())
 
     def test_unlink_missing_profile(self):

--- a/netbox_data_import/tests/test_views.py
+++ b/netbox_data_import/tests/test_views.py
@@ -1559,6 +1559,33 @@ class SearchNetBoxObjectsExtendedViewTest(BaseViewTestCase):
         self.assertIn("serial", result)
         self.assertEqual(result["serial"], "ABC123XYZ")
 
+    def test_full_string_match_not_pushed_off_by_token_noise(self):
+        """When short tokens like 'rc1' match many devices, the exact-substring
+        match must still appear in the result list (limit=20)."""
+        import json
+        from dcim.models import Device
+
+        # 25 devices that match the noisy "rc1" token but NOT "prod-lab03d-rc1"
+        for i in range(25):
+            Device.objects.create(
+                name=f"other-rc1-{i:02d}",
+                device_type=self.dt,
+                role=self.role,
+                site=self.site,
+            )
+        # The target device — full-string match
+        target = Device.objects.create(
+            name="prod-lab03d-rc1",
+            device_type=self.dt,
+            role=self.role,
+            site=self.site,
+        )
+        resp = self.client.get(self.url + "?type=device&q=prod-lab03d-rc1")
+        self.assertEqual(resp.status_code, 200)
+        data = json.loads(resp.content)
+        names = [r["name"] for r in data["results"]]
+        self.assertIn(target.name, names, f"Target device pushed off result list; got {names}")
+
     def test_device_serial_null_when_not_set(self):
         """Device search results include serial=null when not set."""
         import json

--- a/netbox_data_import/tests/test_views_coverage2.py
+++ b/netbox_data_import/tests/test_views_coverage2.py
@@ -393,7 +393,12 @@ class SyncDeviceFieldErrorPathsTest(TestCase):
         self.assertIn("not syncable", data["error"].lower())
 
     def test_face_front_sets_face_and_returns_ok(self):
-        """face='front' is valid → ok=True — lines 1100-1108."""
+        """face='front' is valid when device has a rack → ok=True."""
+        from dcim.models import Rack
+
+        rack = Rack.objects.create(name="SyncErr2Rack", site=self.device.site, u_height=42)
+        self.device.rack = rack
+        self.device.save()
         resp = self.client.post(self.url, {"device_id": self.device.pk, "field": "face", "value": "front"})
         self.assertEqual(resp.status_code, 200)
         self.assertTrue(resp.json()["ok"])

--- a/netbox_data_import/urls.py
+++ b/netbox_data_import/urls.py
@@ -67,6 +67,7 @@ urlpatterns = [
     # Quick-resolve views
     path("remove-extra-ip/", views.RemoveExtraIpView.as_view(), name="remove_extra_ip"),
     path("sync-device-field/", views.SyncDeviceFieldView.as_view(), name="sync_device_field"),
+    path("sync-placement/", views.SyncPlacementView.as_view(), name="sync_placement"),
     # Save resolution (rerere)
     path("save-resolution/", views.SaveResolutionView.as_view(), name="save_resolution"),
     # Source resolutions list (per profile)

--- a/netbox_data_import/views.py
+++ b/netbox_data_import/views.py
@@ -1073,22 +1073,22 @@ class _AjaxPermissionView(ConditionalLoginRequiredMixin, View):
     """Base for AJAX/JSON endpoints — inherits NetBox's ``ConditionalLoginRequiredMixin``.
 
     Subclasses set ``permission_required`` (a Django permission string) to gate
-    access. Authenticated users without the permission receive a JSON
-    ``{"ok": false, "error": "Permission denied"}`` response (HTTP 403) instead
-    of NetBox's default HTML 403 page; unauthenticated users are redirected to
-    the login page when ``settings.LOGIN_REQUIRED`` is true.
+    access. Unauthenticated requests receive a JSON 401 (never a redirect, since
+    these endpoints are called via ``fetch``). Authenticated users without the
+    required permission receive a JSON 403. ``ConditionalLoginRequiredMixin`` is
+    still inherited so that login redirects work if the request is ever reached
+    via a browser navigation (e.g. direct URL), but the explicit checks above
+    fire first for API callers.
     """
 
     permission_required = None
 
     def dispatch(self, request, *args, **kwargs):
-        if (
-            self.permission_required
-            and request.user.is_authenticated
-            and not request.user.has_perm(self.permission_required)
-        ):
-            from django.http import JsonResponse
+        from django.http import JsonResponse
 
+        if not request.user.is_authenticated:
+            return JsonResponse({"ok": False, "error": "Authentication required"}, status=401)
+        if self.permission_required and not request.user.has_perm(self.permission_required):
             return JsonResponse({"ok": False, "error": "Permission denied"}, status=403)
         return super().dispatch(request, *args, **kwargs)
 
@@ -1098,7 +1098,7 @@ class SyncDeviceFieldView(_AjaxPermissionView):
 
     permission_required = "dcim.change_device"
 
-    _ALLOWED_FIELDS = {"device_name", "u_position", "status", "serial", "asset_tag", "face", "rack_name"}
+    _ALLOWED_FIELDS = {"device_name", "u_position", "status", "serial", "asset_tag", "face"}
 
     def post(self, request):
         """Apply the given field value to the specified device."""
@@ -1188,14 +1188,6 @@ class SyncDeviceFieldView(_AjaxPermissionView):
             device.face = mapped
             device.save(update_fields=["face"])
             return device.face
-
-        if field == "rack_name":
-            rack, err = _lookup_rack_for_device(device, value)
-            if err:
-                raise ValueError(err)
-            device.rack = rack
-            device.save(update_fields=["rack"])
-            return rack.name
 
         raise ValueError(f"Field '{field}' is not syncable")
 

--- a/netbox_data_import/views.py
+++ b/netbox_data_import/views.py
@@ -13,6 +13,7 @@ from django.utils.http import url_has_allowed_host_and_scheme
 from django.views import View
 from netbox.views import generic
 from utilities.permissions import get_permission_for_model
+from utilities.views import ConditionalLoginRequiredMixin
 
 from .filters import ImportProfileFilterSet
 from .forms import (
@@ -1068,7 +1069,31 @@ class RemoveExtraIpView(PermissionRequiredMixin, View):
 # ---------------------------------------------------------------------------
 
 
-class SyncDeviceFieldView(PermissionRequiredMixin, View):
+class _AjaxPermissionView(ConditionalLoginRequiredMixin, View):
+    """Base for AJAX/JSON endpoints — inherits NetBox's ``ConditionalLoginRequiredMixin``.
+
+    Subclasses set ``permission_required`` (a Django permission string) to gate
+    access. Authenticated users without the permission receive a JSON
+    ``{"ok": false, "error": "Permission denied"}`` response (HTTP 403) instead
+    of NetBox's default HTML 403 page; unauthenticated users are redirected to
+    the login page when ``settings.LOGIN_REQUIRED`` is true.
+    """
+
+    permission_required = None
+
+    def dispatch(self, request, *args, **kwargs):
+        if (
+            self.permission_required
+            and request.user.is_authenticated
+            and not request.user.has_perm(self.permission_required)
+        ):
+            from django.http import JsonResponse
+
+            return JsonResponse({"ok": False, "error": "Permission denied"}, status=403)
+        return super().dispatch(request, *args, **kwargs)
+
+
+class SyncDeviceFieldView(_AjaxPermissionView):
     """Apply a single field value from the import file to an existing NetBox device."""
 
     permission_required = "dcim.change_device"
@@ -1208,7 +1233,7 @@ def _lookup_rack_for_device(device, value):
     return racks[0], None
 
 
-class SyncPlacementView(PermissionRequiredMixin, View):
+class SyncPlacementView(_AjaxPermissionView):
     """Atomically sync rack + (optional) u_position + (optional) face for a device.
 
     All-or-nothing: if the rack lookup fails, nothing is saved.
@@ -1286,7 +1311,7 @@ class SyncPlacementView(PermissionRequiredMixin, View):
 # ---------------------------------------------------------------------------
 
 
-class SaveResolutionView(PermissionRequiredMixin, View):
+class SaveResolutionView(_AjaxPermissionView):
     """Save a manual field resolution for rerere replay."""
 
     permission_required = "netbox_data_import.add_sourceresolution"
@@ -2044,23 +2069,6 @@ def _device_name_filter(q: str):
     return base
 
 
-class _AjaxPermissionView(PermissionRequiredMixin, View):
-    """Base for AJAX endpoints that require a permission.
-
-    Returns a JSON ``{"ok": false, "error": "Permission denied"}`` response
-    (HTTP 403) for authenticated users who lack the required permission,
-    instead of the default HTML 403 page.  Unauthenticated users are still
-    redirected to the login page.
-    """
-
-    def handle_no_permission(self):
-        from django.http import JsonResponse
-
-        if self.request.user.is_authenticated:
-            return JsonResponse({"ok": False, "error": "Permission denied"}, status=403)
-        return super().handle_no_permission()
-
-
 class SearchNetBoxObjectsView(_AjaxPermissionView):
     """AJAX search endpoint for NetBox objects used in preview quick-fix modals.
 
@@ -2192,7 +2200,7 @@ class SearchNetBoxObjectsView(_AjaxPermissionView):
             )
 
 
-class QuickCreateDeviceRoleView(PermissionRequiredMixin, View):
+class QuickCreateDeviceRoleView(_AjaxPermissionView):
     """AJAX endpoint: create a new DeviceRole and return its details as JSON.
 
     Used by the Configure Class modal so operators can create missing roles
@@ -2439,7 +2447,7 @@ class SyncSingleRowView(_AjaxPermissionView):
         )
 
 
-class UnlinkDeviceView(PermissionRequiredMixin, View):
+class UnlinkDeviceView(_AjaxPermissionView):
     """Remove a DeviceExistingMatch (unlink a manually-linked device)."""
 
     permission_required = "netbox_data_import.delete_deviceexistingmatch"

--- a/netbox_data_import/views.py
+++ b/netbox_data_import/views.py
@@ -1073,7 +1073,7 @@ class SyncDeviceFieldView(PermissionRequiredMixin, View):
 
     permission_required = "dcim.change_device"
 
-    _ALLOWED_FIELDS = {"device_name", "u_position", "status", "serial", "asset_tag", "face"}
+    _ALLOWED_FIELDS = {"device_name", "u_position", "status", "serial", "asset_tag", "face", "rack_name"}
 
     def post(self, request):
         """Apply the given field value to the specified device."""
@@ -1151,6 +1151,10 @@ class SyncDeviceFieldView(PermissionRequiredMixin, View):
             return device.asset_tag
 
         if field == "face":
+            if device.rack_id is None:
+                raise ValueError(
+                    "Cannot set face: device has no rack assigned. Sync rack first, or use Sync Placement."
+                )
             v = str(value).strip().lower()
             _FACE_MAP = {"front": "front", "rear": "rear", "0": "front", "1": "rear"}
             mapped = _FACE_MAP.get(v)
@@ -1160,7 +1164,109 @@ class SyncDeviceFieldView(PermissionRequiredMixin, View):
             device.save(update_fields=["face"])
             return device.face
 
+        if field == "rack_name":
+            rack = _lookup_rack_for_device(device, value)
+            device.rack = rack
+            device.save(update_fields=["rack"])
+            return rack.name
+
         raise ValueError(f"Field '{field}' is not syncable")
+
+
+def _lookup_rack_for_device(device, value):
+    """Look up a Rack by name within ``device.site``, honoring ``device.location``.
+
+    If the device has a location set, the rack must be in the same location. If the
+    device has no location, the rack must also have no location (the implicit
+    "default location" semantic). Raises ValueError on miss/ambiguity.
+    """
+    from dcim.models import Rack
+
+    name = (str(value) if value is not None else "").strip()
+    if not name:
+        raise ValueError("Rack name is empty")
+    if device.site_id is None:
+        raise ValueError("Device has no site; cannot resolve rack")
+    qs = Rack.objects.filter(site=device.site, name=name)
+    if device.location_id is not None:
+        qs = qs.filter(location=device.location)
+        loc_str = f" / location '{device.location}'"
+    else:
+        qs = qs.filter(location__isnull=True)
+        loc_str = ""
+    racks = list(qs[:2])
+    if not racks:
+        raise ValueError(f"Rack '{name}' not found in site '{device.site}'{loc_str}")
+    if len(racks) > 1:
+        raise ValueError(f"Multiple racks named '{name}' found; cannot disambiguate")
+    return racks[0]
+
+
+class SyncPlacementView(PermissionRequiredMixin, View):
+    """Atomically sync rack + (optional) u_position + (optional) face for a device.
+
+    All-or-nothing: if the rack lookup fails, nothing is saved.
+    """
+
+    permission_required = "dcim.change_device"
+
+    def post(self, request):
+        """Resolve rack and atomically set rack + optional position + optional face."""
+        from django.http import JsonResponse
+
+        from dcim.models import Device
+
+        device_id = request.POST.get("device_id")
+        rack_name = request.POST.get("rack_name", "")
+        u_position = request.POST.get("u_position", "")
+        face = request.POST.get("face", "")
+
+        try:
+            device = Device.objects.select_related("site", "location", "rack").get(pk=device_id)
+        except (Device.DoesNotExist, ValueError, TypeError):
+            return JsonResponse({"ok": False, "error": "Device not found"})
+
+        try:
+            rack = _lookup_rack_for_device(device, rack_name)
+        except ValueError as exc:
+            return JsonResponse({"ok": False, "error": str(exc)})
+
+        update_fields = ["rack"]
+        device.rack = rack
+
+        if u_position not in ("", None):
+            try:
+                device.position = int(u_position)
+            except (ValueError, TypeError):
+                return JsonResponse({"ok": False, "error": f"Cannot parse '{u_position}' as integer for u_position"})
+            update_fields.append("position")
+
+        if face not in ("", None):
+            v = str(face).strip().lower()
+            _FACE_MAP = {"front": "front", "rear": "rear", "0": "front", "1": "rear"}
+            mapped = _FACE_MAP.get(v)
+            if mapped is None:
+                return JsonResponse({"ok": False, "error": f"Unknown face value '{face}' — expected 'front' or 'rear'"})
+            device.face = mapped
+            update_fields.append("face")
+
+        try:
+            device.full_clean()
+        except Exception as exc:
+            return JsonResponse({"ok": False, "error": f"Validation failed: {exc}"})
+
+        try:
+            device.save(update_fields=update_fields)
+        except Exception:
+            logger.exception("SyncPlacementView save failed for device_id=%s", device_id)
+            return JsonResponse({"ok": False, "error": "An internal error occurred."}, status=500)
+
+        parts = [f"rack={rack.name}"]
+        if "position" in update_fields:
+            parts.append(f"U{device.position}")
+        if "face" in update_fields:
+            parts.append(device.face)
+        return JsonResponse({"ok": True, "display": ", ".join(parts)})
 
 
 # ---------------------------------------------------------------------------

--- a/netbox_data_import/views.py
+++ b/netbox_data_import/views.py
@@ -2060,7 +2060,7 @@ class SearchNetBoxObjectsView(_AjaxPermissionView):
 
     def get(self, request):
         """Return a JSON list of matching NetBox objects for the given type and query."""
-        from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, RackType
+        from dcim.models import DeviceRole, DeviceType, Manufacturer, RackType
         from django.http import JsonResponse
 
         obj_type = request.GET.get("type", "device")
@@ -2108,16 +2108,7 @@ class SearchNetBoxObjectsView(_AjaxPermissionView):
                     }
                 )
         elif obj_type == "device":
-            for dev in Device.objects.filter(_device_name_filter(q)).distinct().select_related("site")[:limit]:
-                results.append(
-                    {
-                        "id": dev.pk,
-                        "name": dev.name,
-                        "serial": dev.serial or None,
-                        "site": dev.site.name if dev.site else "",
-                        "url": request.build_absolute_uri(dev.get_absolute_url()),
-                    }
-                )
+            self._search_devices(request, q, limit, results)
         elif obj_type == "role":
             for role in DeviceRole.objects.filter(name__icontains=q)[:limit]:
                 results.append(
@@ -2145,6 +2136,48 @@ class SearchNetBoxObjectsView(_AjaxPermissionView):
                 )
 
         return JsonResponse({"results": results})
+
+    def _search_devices(self, request, q, limit, results):
+        """Two-phase device search: full-string matches first, then token matches.
+
+        This prevents a relevant exact-substring match (e.g. "prod-lab03d-rc1")
+        from being pushed off the result list by noisy short tokens like "rc1"
+        or "prod" that match many devices.
+        """
+        from dcim.models import Device
+
+        base_qs = Device.objects.filter(name__icontains=q).distinct().select_related("site").order_by("name")
+        seen_ids = set()
+        for dev in base_qs[:limit]:
+            seen_ids.add(dev.pk)
+            results.append(
+                {
+                    "id": dev.pk,
+                    "name": dev.name,
+                    "serial": dev.serial or None,
+                    "site": dev.site.name if dev.site else "",
+                    "url": request.build_absolute_uri(dev.get_absolute_url()),
+                }
+            )
+        if len(results) >= limit:
+            return
+        token_qs = (
+            Device.objects.filter(_device_name_filter(q))
+            .exclude(pk__in=seen_ids)
+            .distinct()
+            .select_related("site")
+            .order_by("name")
+        )
+        for dev in token_qs[: limit - len(results)]:
+            results.append(
+                {
+                    "id": dev.pk,
+                    "name": dev.name,
+                    "serial": dev.serial or None,
+                    "site": dev.site.name if dev.site else "",
+                    "url": request.build_absolute_uri(dev.get_absolute_url()),
+                }
+            )
 
 
 class QuickCreateDeviceRoleView(PermissionRequiredMixin, View):

--- a/netbox_data_import/views.py
+++ b/netbox_data_import/views.py
@@ -1165,7 +1165,9 @@ class SyncDeviceFieldView(PermissionRequiredMixin, View):
             return device.face
 
         if field == "rack_name":
-            rack = _lookup_rack_for_device(device, value)
+            rack, err = _lookup_rack_for_device(device, value)
+            if err:
+                raise ValueError(err)
             device.rack = rack
             device.save(update_fields=["rack"])
             return rack.name
@@ -1178,15 +1180,19 @@ def _lookup_rack_for_device(device, value):
 
     If the device has a location set, the rack must be in the same location. If the
     device has no location, the rack must also have no location (the implicit
-    "default location" semantic). Raises ValueError on miss/ambiguity.
+    "default location" semantic).
+
+    Returns ``(rack, None)`` on success or ``(None, error_message)`` on failure.
+    Error messages are static, controlled strings — no exception text is exposed,
+    so the result is safe to return directly to the client.
     """
     from dcim.models import Rack
 
     name = (str(value) if value is not None else "").strip()
     if not name:
-        raise ValueError("Rack name is empty")
+        return None, "Rack name is empty"
     if device.site_id is None:
-        raise ValueError("Device has no site; cannot resolve rack")
+        return None, "Device has no site; cannot resolve rack"
     qs = Rack.objects.filter(site=device.site, name=name)
     if device.location_id is not None:
         qs = qs.filter(location=device.location)
@@ -1196,10 +1202,10 @@ def _lookup_rack_for_device(device, value):
         loc_str = ""
     racks = list(qs[:2])
     if not racks:
-        raise ValueError(f"Rack '{name}' not found in site '{device.site}'{loc_str}")
+        return None, f"Rack '{name}' not found in site '{device.site}'{loc_str}"
     if len(racks) > 1:
-        raise ValueError(f"Multiple racks named '{name}' found; cannot disambiguate")
-    return racks[0]
+        return None, f"Multiple racks named '{name}' found; cannot disambiguate"
+    return racks[0], None
 
 
 class SyncPlacementView(PermissionRequiredMixin, View):
@@ -1226,10 +1232,9 @@ class SyncPlacementView(PermissionRequiredMixin, View):
         except (Device.DoesNotExist, ValueError, TypeError):
             return JsonResponse({"ok": False, "error": "Device not found"})
 
-        try:
-            rack = _lookup_rack_for_device(device, rack_name)
-        except ValueError as exc:
-            return JsonResponse({"ok": False, "error": str(exc)})
+        rack, err = _lookup_rack_for_device(device, rack_name)
+        if err:
+            return JsonResponse({"ok": False, "error": err})
 
         update_fields = ["rack"]
         device.rack = rack
@@ -1252,8 +1257,15 @@ class SyncPlacementView(PermissionRequiredMixin, View):
 
         try:
             device.full_clean()
-        except Exception as exc:
-            return JsonResponse({"ok": False, "error": f"Validation failed: {exc}"})
+        except ValidationError as exc:
+            if hasattr(exc, "message_dict"):
+                msg = "; ".join(f"{f}: {', '.join(es)}" for f, es in exc.message_dict.items())
+            else:
+                msg = "; ".join(exc.messages)
+            return JsonResponse({"ok": False, "error": f"Validation failed: {msg}"}, status=400)
+        except Exception:
+            logger.exception("SyncPlacementView full_clean failed for device_id=%s", device_id)
+            return JsonResponse({"ok": False, "error": "An internal error occurred."}, status=500)
 
         try:
             device.save(update_fields=update_fields)


### PR DESCRIPTION
Adds the ability to sync rack assignment for matched devices and prevents the validation error 'Cannot select a rack face without assigning a rack' that would otherwise leave devices in an inconsistent state.

- SyncDeviceFieldView: 'rack_name' added to _ALLOWED_FIELDS; rack resolved by name scoped to device.site and (optionally) device.location. Lookup errors and ambiguity produce clear messages.
- SyncDeviceFieldView: syncing 'face' now requires the device to already have a rack; otherwise returns a clear error and saves nothing.
- New SyncPlacementView (POST /sync-placement/): atomically sets rack + optional position + optional face in a single save(). All-or-nothing: if rack lookup fails, nothing is saved. Runs full_clean() before save.
- import_preview.html: a 'Sync placement' button appears on update rows that have a non-empty rack_name, alongside the existing per-field sync buttons. New JS handler posts to /sync-placement/.
- Tests: 14 new tests covering rack lookup (site only / with location / not found / ambiguous / empty), face dependency guard, placement happy path / rack only / atomic on lookup failure / bad face / missing device / permissions. Existing face test updated to assign a rack first.

Closes #28.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New "Sync placement" control in the import preview to atomically update a device’s rack, U-position, and orientation with live "Syncing…" feedback and success/failure states.

* **Bug Fixes / Improvements**
  * Orientation (face) updates now require an assigned rack.
  * API endpoints now return consistent JSON 401/403 for auth/permission errors.
  * Search prioritizes full-string device matches to avoid token-noise issues.

* **Tests**
  * Added tests for placement sync, validation/error paths, and AJAX search regression.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marcinpsk/netbox-data-import-plugin/pull/36?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->